### PR TITLE
WIP: docs(CLI-INSTALLATION): Move headings back to h2

### DIFF
--- a/docs/CLI-INSTALLATION.md
+++ b/docs/CLI-INSTALLATION.md
@@ -1,4 +1,8 @@
-### macOS and GNU/Linux
+CLI Installation
+================
+
+macOS and GNU/Linux
+--------------------
 
 - Extract the `.tar.gz` package by running:
 
@@ -15,7 +19,8 @@ tar fvx path/to/cli.tar.gz
 export PATH="$PATH:/opt/etcher-cli"
 ```
 
-### Windows
+Windows
+-------
 
 - Unzip the `.zip` package by right-clicking on it and selecting "Extract All"
 
@@ -43,13 +48,15 @@ export PATH="$PATH:/opt/etcher-cli"
 
   - Re-open `cmd.exe`, or PowerShell
 
-### Running
+Running
+=======
 
 ```sh
 etcher -v
 ```
 
-### Options
+Options
+-------
 
 ```
   --help, -h     show help


### PR DESCRIPTION
Also add some h1 headers

Ping @craig-mulligan @jviotti 

This is WIP because it depends on https://github.com/resin-io/etcher-homepage/issues/47 (and shouldn't be merged until after that's been fixed).

BTW Juanchi - why is the CLI executable named just `etcher` and not `etcher-cli` or `etcher-node` as a counterpart to `etcher-electron` ?