### PR TITLE
feat(GUI): use relative units in flash speed

### DIFF
--- a/lib/gui/app/app.js
+++ b/lib/gui/app/app.js
@@ -189,7 +189,7 @@ app.run(() => {
     // `undefined` values.
     analytics.logDebug(
       `Progress (${currentFlashState.type}): ` +
-      `${currentFlashState.percentage}% at ${currentFlashState.speed} MB/s ` +
+      `${currentFlashState.percentage}% at ${currentFlashState.humanSpeed} ` +
       `(eta ${currentFlashState.eta}s)`
     )
 

--- a/lib/gui/app/pages/main/templates/main.tpl.html
+++ b/lib/gui/app/pages/main/templates/main.tpl.html
@@ -103,7 +103,7 @@
         </progress-button>
 
         <p class="step-footer step-footer-split" ng-if="main.state.getFlashState().speed && main.state.getFlashState().percentage != 100">
-          <span ng-bind="main.state.getFlashState().speed.toFixed(2) + ' MB/s'"></span>
+          <span ng-bind="main.state.getFlashState().humanSpeed"></span>
           <span>ETA: {{ main.state.getFlashState().eta | secondsToDate | amDateFormat:'m[m]ss[s]' }}</span>
         </p>
       </div>

--- a/lib/shared/models/flash-state.js
+++ b/lib/shared/models/flash-state.js
@@ -114,25 +114,25 @@ exports.unsetFlashingFlag = (results) => {
  * });
  */
 exports.setProgressState = (state) => {
+  const pickedState = _.pick(state, [
+    'type',
+    'percentage',
+    'eta',
+    'speed'
+  ])
+
+  const humanSpeed = units.bytesToClosestUnit(state.speed, '/s')
+
+  const data = _.assign({}, pickedState, {
+    humanSpeed,
+    percentage: _.isFinite(state.percentage)
+      ? Math.floor(state.percentage)
+      : state.percentage
+  })
+
   store.dispatch({
     type: store.Actions.SET_FLASH_STATE,
-    data: {
-      type: state.type,
-      percentage: _.isNumber(state.percentage) && !_.isNaN(state.percentage)
-        ? Math.floor(state.percentage)
-        : state.percentage,
-      eta: state.eta,
-
-      speed: _.attempt(() => {
-        if (_.isNumber(state.speed) && !_.isNaN(state.speed)) {
-          // Preserve only two decimal places
-          const PRECISION = 2
-          return _.round(units.bytesToMegabytes(state.speed), PRECISION)
-        }
-
-        return null
-      })
-    }
+    data
   })
 }
 

--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -60,7 +60,8 @@ const flashStateNoNilFields = [
   'type',
   'percentage',
   'eta',
-  'speed'
+  'speed',
+  'humanSpeed'
 ]
 
 /**
@@ -87,7 +88,8 @@ const DEFAULT_STATE = Immutable.fromJS({
   flashResults: {},
   flashState: {
     percentage: 0,
-    speed: 0
+    speed: 0,
+    humanSpeed: ''
   },
   settings: {
     unsafeMode: false,

--- a/lib/shared/units.js
+++ b/lib/shared/units.js
@@ -21,17 +21,6 @@ const _ = require('lodash')
 const prettyBytes = require('pretty-bytes')
 
 /**
- * @summary Megabyte to byte ratio
- * @constant
- * @private
- * @type {Number}
- *
- * @description
- * 1 MB = 1e+6 B
- */
-const MEGABYTE_TO_BYTE_RATIO = 1e+6
-
-/**
  * @summary Milliseconds in a day
  * @constant
  * @private
@@ -43,35 +32,21 @@ const MEGABYTE_TO_BYTE_RATIO = 1e+6
 const MILLISECONDS_IN_A_DAY = 86400000
 
 /**
- * @summary Convert bytes to megabytes
- * @function
- * @public
- *
- * @param {Number} bytes - bytes
- * @returns {Number} megabytes
- *
- * @example
- * const result = units.bytesToMegabytes(7801405440);
- */
-exports.bytesToMegabytes = (bytes) => {
-  return bytes / MEGABYTE_TO_BYTE_RATIO
-}
-
-/**
  * @summary Convert bytes to most appropriate unit string
  * @function
  * @public
  *
  * @param {Number} bytes - bytes
+ * @param {String} [suffix=''] - suffix string e.g. '/s'
  * @returns {String} size and unit string
  *
  * @example
- * const humanReadable = units.bytesToClosestUnit(7801405440);
- * > '7.8 GB'
+ * const humanReadable = units.bytesToClosestUnit(7801405440, '/s');
+ * > '7.8 GB/s'
  */
-exports.bytesToClosestUnit = (bytes) => {
-  if (_.isNumber(bytes)) {
-    return prettyBytes(bytes)
+exports.bytesToClosestUnit = (bytes, suffix = '') => {
+  if (_.isFinite(bytes)) {
+    return prettyBytes(bytes) + suffix
   }
 
   return null

--- a/tests/shared/models/flash-state.spec.js
+++ b/tests/shared/models/flash-state.spec.js
@@ -26,7 +26,7 @@ describe('Model: flashState', function () {
 
   describe('flashState', function () {
     describe('.resetState()', function () {
-      it('should be able to reset the progress state', function () {
+      it('should be able to reset the progress state while flashing', function () {
         flashState.setFlashingFlag()
         flashState.setProgressState({
           type: 'write',
@@ -39,11 +39,12 @@ describe('Model: flashState', function () {
 
         m.chai.expect(flashState.getFlashState()).to.deep.equal({
           percentage: 0,
-          speed: 0
+          speed: 0,
+          humanSpeed: ''
         })
       })
 
-      it('should be able to reset the progress state', function () {
+      it('should be able to reset the progress state after flashing', function () {
         flashState.unsetFlashingFlag({
           cancelled: false,
           sourceChecksum: '1234'
@@ -234,6 +235,23 @@ describe('Model: flashState', function () {
         }).to.not.throw('Missing flash fields: speed')
       })
 
+      it('should set the .humanSpeed field', function () {
+        const state = {
+          type: 'write',
+          percentage: 50,
+          eta: 15,
+          speed: 10000000
+        }
+
+        flashState.setFlashingFlag()
+        flashState.setProgressState(state)
+
+        // eslint-disable-next-line lodash/prefer-lodash-method
+        m.chai.expect(flashState.getFlashState()).to.deep.equal(Object.assign({}, state, {
+          humanSpeed: '10 MB/s'
+        }))
+      })
+
       it('should floor the percentage number', function () {
         flashState.setFlashingFlag()
         flashState.setProgressState({
@@ -244,6 +262,16 @@ describe('Model: flashState', function () {
         })
 
         m.chai.expect(flashState.getFlashState().percentage).to.equal(50)
+      })
+
+      it('should check for path existence and whether undefined', function () {
+        flashState.setFlashingFlag()
+        m.chai.expect(function () {
+          flashState.setProgressState({
+            type: undefined,
+            percentage: undefined
+          })
+        }).to.throw('Missing flash fields: type, percentage, eta, speed, humanSpeed')
       })
     })
 
@@ -268,7 +296,8 @@ describe('Model: flashState', function () {
         const currentFlashState = flashState.getFlashState()
         m.chai.expect(currentFlashState).to.deep.equal({
           percentage: 0,
-          speed: 0
+          speed: 0,
+          humanSpeed: ''
         })
       })
 
@@ -283,7 +312,11 @@ describe('Model: flashState', function () {
         flashState.setFlashingFlag()
         flashState.setProgressState(state)
         const currentFlashState = flashState.getFlashState()
-        m.chai.expect(currentFlashState).to.deep.equal(state)
+
+        // eslint-disable-next-line lodash/prefer-lodash-method
+        m.chai.expect(currentFlashState).to.deep.equal(Object.assign({
+          humanSpeed: '0 B/s'
+        }, state))
       })
     })
 
@@ -378,7 +411,8 @@ describe('Model: flashState', function () {
 
         m.chai.expect(flashState.getFlashState()).to.not.deep.equal({
           percentage: 0,
-          speed: 0
+          speed: 0,
+          humanSpeed: '0 B/s'
         })
 
         flashState.unsetFlashingFlag({
@@ -388,7 +422,8 @@ describe('Model: flashState', function () {
 
         m.chai.expect(flashState.getFlashState()).to.deep.equal({
           percentage: 0,
-          speed: 0
+          speed: 0,
+          humanSpeed: ''
         })
       })
 

--- a/tests/shared/units.spec.js
+++ b/tests/shared/units.spec.js
@@ -51,11 +51,4 @@ describe('Shared: Units', function () {
       m.chai.expect(units.bytesToClosestUnit(999)).to.equal('999 B')
     })
   })
-
-  describe('.bytesToMegabytes()', function () {
-    it('should convert bytes to megabytes', function () {
-      m.chai.expect(units.bytesToMegabytes(1.2e+7)).to.equal(12)
-      m.chai.expect(units.bytesToMegabytes(332000)).to.equal(0.332)
-    })
-  })
 })


### PR DESCRIPTION
We utilize the relative unit functionality in the flashing speed status.

Changelog-Entry: Use relative units in the flashing speed status.