### PR TITLE
 style: add metainformation for linux menus 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ COMPANY_NAME = Resinio Ltd
 APPLICATION_NAME = $(shell jq -r '.displayName' package.json)
 APPLICATION_DESCRIPTION = $(shell jq -r '.description' package.json)
 APPLICATION_COPYRIGHT = $(shell cat electron-builder.yml | shyaml get-value copyright)
+APPLICATION_MENU_CATEGORIES = $(shell cat electron-builder.yml | shyaml get-value linux.category)
 
 BINTRAY_ORGANIZATION = resin-io
 BINTRAY_REPOSITORY_DEBIAN = debian
@@ -343,6 +344,7 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME_LOWERCASE)-$(APPLICATION_VERSION)-$(PLATFO
 		-r $(TARGET_ARCH) \
 		-b $(APPLICATION_NAME_ELECTRON) \
 		-i assets/icon.png \
+		-c $(APPLICATION_MENU_CATEGORIES) \
 		-o $@
 
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME_LOWERCASE)-$(APPLICATION_VERSION)-$(TARGET_ARCH_APPIMAGE).AppImage: \

--- a/scripts/build/electron-create-appdir.sh
+++ b/scripts/build/electron-create-appdir.sh
@@ -30,6 +30,7 @@ function usage() {
   echo "    -r <application architecture>"
   echo "    -b <application binary name>"
   echo "    -i <application icon (.png)>"
+  echo "    -c <application menu categories>"
   echo "    -o <output>"
   exit 1
 }
@@ -40,9 +41,10 @@ ARGV_PACKAGE=""
 ARGV_ARCHITECTURE=""
 ARGV_BINARY=""
 ARGV_ICON=""
+ARGV_MENU_CATEGORIES=""
 ARGV_OUTPUT=""
 
-while getopts ":n:d:p:r:b:i:o:" option; do
+while getopts ":n:d:p:r:b:i:c:o:" option; do
   case $option in
     n) ARGV_APPLICATION_NAME="$OPTARG" ;;
     d) ARGV_DESCRIPTION="$OPTARG" ;;
@@ -51,6 +53,7 @@ while getopts ":n:d:p:r:b:i:o:" option; do
     b) ARGV_BINARY="$OPTARG" ;;
     i) ARGV_ICON="$OPTARG" ;;
     o) ARGV_OUTPUT="$OPTARG" ;;
+    c) ARGV_MENU_CATEGORIES="$OPTARG" ;;
     *) usage ;;
   esac
 done
@@ -61,6 +64,7 @@ if [ -z "$ARGV_APPLICATION_NAME" ] \
   || [ -z "$ARGV_ARCHITECTURE" ] \
   || [ -z "$ARGV_BINARY" ] \
   || [ -z "$ARGV_ICON" ] \
+  || [ -z "$ARGV_MENU_CATEGORIES" ] \
   || [ -z "$ARGV_OUTPUT" ]
 then
   usage
@@ -77,6 +81,7 @@ Exec=$ARGV_BINARY.wrapper
 Comment=$ARGV_DESCRIPTION
 Icon=$APPDIR_ICON_FILENAME
 Type=Application
+Categories=$ARGV_MENU_CATEGORIES
 EOF
 
 cp "$ARGV_ICON" "$ARGV_OUTPUT/$APPDIR_ICON_FILENAME.png"


### PR DESCRIPTION
Now, Etcher, on the basis of the `.desktop` file, is placed in the menus category 'Other'.
With this changes, Etcher will be moved to the menu category for system utilities ('System' category).
