### PR TITLE
feat(GUI): conform to the styleguide buttons

### DIFF
--- a/lib/gui/app/scss/components/_button.scss
+++ b/lib/gui/app/scss/components/_button.scss
@@ -17,16 +17,17 @@
 .button {
   @extend .btn;
 
-  padding: 10px;
-  padding-top: 11px;
+  height: 36px;
 
-  border-radius: 2px;
+  border-radius: 3px;
   border: 0;
 
   letter-spacing: .5px;
   outline: none;
 
   position: relative;
+
+  font-weight: bold;
 
   > .glyphicon {
     top: 2px;

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6111,13 +6111,13 @@ body {
  * limitations under the License.
  */
 .button, .progress-button {
-  padding: 10px;
-  padding-top: 11px;
-  border-radius: 2px;
+  height: 36px;
+  border-radius: 3px;
   border: 0;
   letter-spacing: .5px;
   outline: none;
-  position: relative; }
+  position: relative;
+  font-weight: bold; }
   .button > .glyphicon, .progress-button > .glyphicon, .button > .tick, .progress-button > .tick {
     top: 2px;
     margin-right: 2px; }


### PR DESCRIPTION
We conform to the Resin styleguide buttons, as they are in
[rendition][1], but with Etcher colours. This means bold fonts, slightly
rounder corners, and slightly slimmer buttons.

[1]: https://resin-io-modules.github.io/rendition/?selectedKind=Button&selectedStory=Standard&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

Change-Type: patch
Changelog-Entry: Conform to the Resin styleguide buttons.