### PR TITLE
refactor: use word successful instead of succeeded

### DIFF
--- a/lib/gui/app/modules/progress-status.js
+++ b/lib/gui/app/modules/progress-status.js
@@ -30,7 +30,7 @@ const utils = require('../../../shared/utils')
  * const status = progressStatus.fromFlashState({
  *   flashing: 1,
  *   verifying: 0,
- *   succeeded: 0,
+ *   successful: 0,
  *   failed: 0,
  *   percentage: 55,
  *   speed: 2049

--- a/lib/gui/app/os/window-progress.js
+++ b/lib/gui/app/os/window-progress.js
@@ -40,7 +40,7 @@ const INITIAL_TITLE = document.title
  * const title = getWindowTitle({
  *   flashing: 1,
  *   validating: 0,
- *   succeeded: 0,
+ *   successful: 0,
  *   failed: 0,
  *   percentage: 55,
  *   speed: 2049
@@ -83,7 +83,7 @@ exports.currentWindow = electron.remote.getCurrentWindow()
  * windowProgress.set({
  *   flashing: 1,
  *   validating: 0,
- *   succeeded: 0,
+ *   successful: 0,
  *   failed: 0,
  *   percentage: 55,
  *   speed: 2049

--- a/lib/gui/app/pages/main/styles/_main.scss
+++ b/lib/gui/app/pages/main/styles/_main.scss
@@ -141,7 +141,7 @@ svg-icon > img[disabled] {
     margin-right: 6px;
   }
 
-  &.target-status-succeeded > .target-status-dot {
+  &.target-status-successful > .target-status-dot {
     background-color: $palette-theme-success-background;
   }
   &.target-status-failed > .target-status-dot {

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6603,7 +6603,7 @@ svg-icon > img[disabled] {
     height: 8px;
     border-radius: 50%;
     margin-right: 6px; }
-  .target-status-line.target-status-succeeded > .target-status-dot {
+  .target-status-line.target-status-successful > .target-status-dot {
     background-color: #5fb835; }
   .target-status-line.target-status-failed > .target-status-dot {
     background-color: #d9534f; }

--- a/lib/sdk/writer/index.js
+++ b/lib/sdk/writer/index.js
@@ -399,13 +399,13 @@ class ImageWriter extends EventEmitter {
     state.flashing = 0
     state.verifying = 0
     state.failed = 0
-    state.succeeded = 0
+    state.successful = 0
 
     this.destinations.forEach((dest) => {
       state.flashing += !dest.error && !dest.finished ? 1 : 0
       state.verifying += !dest.error && dest.finished && !dest.verified ? 1 : 0
       state.failed += dest.error ? 1 : 0
-      state.succeeded += !dest.error && dest.finished && (dest.verified || !this.verifyChecksums) ? 1 : 0
+      state.successful += !dest.error && dest.finished && (dest.verified || !this.verifyChecksums) ? 1 : 0
       if (!(dest.finished && dest.verified) && !dest.error) {
         state.totalSpeed += state.type === 'write'
           ? (dest.stream.speed || 0)
@@ -634,13 +634,13 @@ class ImageWriter extends EventEmitter {
   _finish () {
     this._cleanup(() => {
       const failures = []
-      let succeeded = 0
+      let successful = 0
       let failed = 0
 
       this.finished = true
 
       this.destinations.forEach((dest) => {
-        succeeded += dest.finished && dest.verified && !dest.error ? 1 : 0
+        successful += dest.finished && dest.verified && !dest.error ? 1 : 0
         failed += dest.error ? 1 : 0
         if (dest.error) {
           dest.error.device = dest.device.device
@@ -649,7 +649,7 @@ class ImageWriter extends EventEmitter {
       })
 
       this.emit('finish', {
-        devices: { succeeded, failed },
+        devices: { successful, failed },
         bytesRead: this.bytesRead,
         bytesWritten: this.bytesWritten,
         checksum: this.checksum,

--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -32,10 +32,10 @@ module.exports = {
    */
   progress: {
 
-    succeeded: (quantity) => {
+    successful: (quantity) => {
       // eslint-disable-next-line no-magic-numbers
       const plural = quantity === 1 ? '' : 's'
-      return `Succeeded device${plural}`
+      return `Successful device${plural}`
     },
 
     failed: (quantity) => {

--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -90,7 +90,7 @@ const DEFAULT_STATE = Immutable.fromJS({
   flashState: {
     flashing: 0,
     verifying: 0,
-    succeeded: 0,
+    successful: 0,
     failed: 0,
     percentage: 0,
     speed: 0,
@@ -249,7 +249,7 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
       if (!_.every(_.pick(action.data, [
         'flashing',
         'verifying',
-        'succeeded',
+        'successful',
         'failed'
       ]), _.isFinite)) {
         throw errors.createError({

--- a/tests/shared/models/flash-state.spec.js
+++ b/tests/shared/models/flash-state.spec.js
@@ -31,7 +31,7 @@ describe('Model: flashState', function () {
         flashState.setProgressState({
           flashing: 2,
           verifying: 0,
-          succeeded: 0,
+          successful: 0,
           failed: 0,
           type: 'write',
           percentage: 50,
@@ -45,7 +45,7 @@ describe('Model: flashState', function () {
         m.chai.expect(flashState.getFlashState()).to.deep.equal({
           flashing: 0,
           verifying: 0,
-          succeeded: 0,
+          successful: 0,
           failed: 0,
           percentage: 0,
           speed: 0,
@@ -98,7 +98,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 50,
@@ -115,7 +115,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 0,
@@ -132,7 +132,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             eta: 15,
@@ -148,7 +148,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: '50',
@@ -165,7 +165,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 101,
@@ -182,7 +182,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: -1,
@@ -199,7 +199,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 50,
@@ -215,7 +215,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 50,
@@ -232,7 +232,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 50,
@@ -249,7 +249,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 50,
@@ -265,7 +265,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 50,
@@ -282,7 +282,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 50,
@@ -298,7 +298,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 2,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             type: 'write',
             percentage: 50,
@@ -314,7 +314,7 @@ describe('Model: flashState', function () {
         flashState.setProgressState({
           flashing: 2,
           verifying: 0,
-          succeeded: 0,
+          successful: 0,
           failed: 0,
           type: 'write',
           percentage: 50.253559459485,
@@ -332,7 +332,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: {},
             verifying: [],
-            succeeded: true,
+            successful: true,
             failed: 'string',
             percentage: 0,
             eta: 0,
@@ -348,7 +348,7 @@ describe('Model: flashState', function () {
           flashState.setProgressState({
             flashing: 0,
             verifying: 0,
-            succeeded: 0,
+            successful: 0,
             failed: 0,
             percentage: 0,
             eta: 0,
@@ -381,7 +381,7 @@ describe('Model: flashState', function () {
         m.chai.expect(currentFlashState).to.deep.equal({
           flashing: 0,
           verifying: 0,
-          succeeded: 0,
+          successful: 0,
           failed: 0,
           percentage: 0,
           speed: 0,
@@ -393,7 +393,7 @@ describe('Model: flashState', function () {
         const state = {
           flashing: 1,
           verifying: 0,
-          succeeded: 0,
+          successful: 0,
           failed: 0,
           percentage: 50,
           eta: 15,
@@ -407,7 +407,7 @@ describe('Model: flashState', function () {
         m.chai.expect(currentFlashState).to.deep.equal({
           flashing: 1,
           verifying: 0,
-          succeeded: 0,
+          successful: 0,
           failed: 0,
           percentage: 50,
           eta: 15,
@@ -502,7 +502,7 @@ describe('Model: flashState', function () {
         flashState.setProgressState({
           flashing: 2,
           verifying: 0,
-          succeeded: 0,
+          successful: 0,
           failed: 0,
           type: 'write',
           percentage: 50,
@@ -514,7 +514,7 @@ describe('Model: flashState', function () {
         m.chai.expect(flashState.getFlashState()).to.not.deep.equal({
           flashing: 2,
           verifying: 0,
-          succeeded: 0,
+          successful: 0,
           failed: 0,
           percentage: 0,
           speed: 0,
@@ -529,7 +529,7 @@ describe('Model: flashState', function () {
         m.chai.expect(flashState.getFlashState()).to.deep.equal({
           flashing: 0,
           verifying: 0,
-          succeeded: 0,
+          successful: 0,
           failed: 0,
           percentage: 0,
           speed: 0,


### PR DESCRIPTION
We replace 'succeeded' with 'successful' throughout the codebase.

Change-Type: patch