### PR TITLE
Update Electron to v2

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -66,7 +66,7 @@ deb:
     - libgconf-2-4
     - libgdk-pixbuf2.0-0
     - libglib2.0-0
-    - libgtk3.0-0
+    - libgtk-3-0
     - liblzma5
     - libnotify4
     - libnspr4

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -66,7 +66,7 @@ deb:
     - libgconf-2-4
     - libgdk-pixbuf2.0-0
     - libglib2.0-0
-    - libgtk2.0-0
+    - libgtk3.0-0
     - liblzma5
     - libnotify4
     - libnspr4

--- a/lib/gui/app/components/safe-webview.js
+++ b/lib/gui/app/components/safe-webview.js
@@ -124,6 +124,7 @@ class SafeWebview extends react.PureComponent {
   render () {
     return react.createElement('webview', {
       ref: 'webview',
+      partition: ELECTRON_SESSION,
       style: {
         flex: this.state.shouldShow ? null : '0 1',
         width: this.state.shouldShow ? null : '0',
@@ -140,9 +141,6 @@ class SafeWebview extends react.PureComponent {
     _.map(this.eventTuples, (tuple) => {
       this.refs.webview.addEventListener(...tuple)
     })
-
-    // Use the 'success-banner' session
-    this.refs.webview.partition = ELECTRON_SESSION
 
     // It's important that this comes after the partition setting, otherwise it will
     // use another session and we can't change it without destroying the element again

--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -44,7 +44,7 @@ const createMainWindow = () => {
     fullscreenable: Boolean(config.fullscreen),
     kiosk: Boolean(config.fullscreen),
     autoHideMenuBar: true,
-    titleBarStyle: 'hidden-inset',
+    titleBarStyle: 'hiddenInset',
     icon: path.join(__dirname, '..', '..', 'assets', 'icon.png'),
     darkTheme: true,
     webPreferences: {

--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -72,7 +72,7 @@ const createMainWindow = () => {
   // electron desktop experience fixes in this file.
   //
   // See https://github.com/electron/electron/issues/3609
-  mainWindow.webContents.executeJavaScript('require(\'electron\').webFrame.setZoomLevelLimits(1, 1);')
+  mainWindow.webContents.executeJavaScript('require(\'electron\').webFrame.setVisualZoomLevelLimits(1, 1);')
 
   // Prevent external resources from being loaded (like images)
   // when dropping them on the WebView.

--- a/lib/sdk/adapters/usbboot/usb.js
+++ b/lib/sdk/adapters/usbboot/usb.js
@@ -73,25 +73,25 @@ exports.listDevices = () => {
   })
 
   // Include driverless devices into the list of USB devices.
-  if (process.platform === 'win32') {
-    // NOTE: Temporarily ignore errors when loading winusb-driver-generator,
-    // due to C Runtime issues on Windows;
-    // see https://github.com/resin-io/etcher/issues/1956
-    try {
-      const winusbDriverGenerator = require('winusb-driver-generator')
-      for (const device of winusbDriverGenerator.listDriverlessDevices()) {
-        devices.push({
-          accessible: false,
-          deviceDescriptor: {
-            idVendor: device.vid,
-            idProduct: device.pid
-          }
-        })
-      }
-    } catch (error) {
-      // Ignore error
-    }
-  }
+  // if (process.platform === 'win32') {
+  //   // NOTE: Temporarily ignore errors when loading winusb-driver-generator,
+  //   // due to C Runtime issues on Windows;
+  //   // see https://github.com/resin-io/etcher/issues/1956
+  //   try {
+  //     const winusbDriverGenerator = require('winusb-driver-generator')
+  //     for (const device of winusbDriverGenerator.listDriverlessDevices()) {
+  //       devices.push({
+  //         accessible: false,
+  //         deviceDescriptor: {
+  //           idVendor: device.vid,
+  //           idProduct: device.pid
+  //         }
+  //       })
+  //     }
+  //   } catch (error) {
+  //     // Ignore error
+  //   }
+  // }
 
   return Bluebird.resolve(devices)
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2550,13 +2550,13 @@
       "dev": true
     },
     "electron": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.2.tgz",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.4.tgz",
       "dev": true,
       "dependencies": {
         "@types/node": {
-          "version": "8.10.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.19.tgz",
+          "version": "8.10.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.20.tgz",
           "dev": true
         },
         "debug": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2550,10 +2550,15 @@
       "dev": true
     },
     "electron": {
-      "version": "1.7.13",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.13.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.2.tgz",
       "dev": true,
       "dependencies": {
+        "@types/node": {
+          "version": "8.10.19",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.19.tgz",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4355,8 +4360,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz"
     },
     "home-path": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
       "dev": true
     },
     "homedir-polyfill": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
-    "electron": "1.7.13",
+    "electron": "2.0.2",
     "electron-builder": "19.40.0",
     "electron-mocha": "6.0.1",
     "eslint": "4.17.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
-    "electron": "2.0.2",
+    "electron": "2.0.4",
     "electron-builder": "19.40.0",
     "electron-mocha": "6.0.1",
     "eslint": "4.17.0",

--- a/scripts/build/docker/Dockerfile-armv7hf
+++ b/scripts/build/docker/Dockerfile-armv7hf
@@ -19,7 +19,7 @@ RUN apt-get update \
     jq \
     libasound2 \
     libgconf-2-4 \
-    libgtk2.0-0 \
+    libgtk3.0-0 \
     libudev-dev \
     libusb-1.0-0-dev \
     libnss3 \

--- a/scripts/build/docker/Dockerfile-armv7hf
+++ b/scripts/build/docker/Dockerfile-armv7hf
@@ -19,7 +19,7 @@ RUN apt-get update \
     jq \
     libasound2 \
     libgconf-2-4 \
-    libgtk3.0-0 \
+    libgtk-3-0 \
     libudev-dev \
     libusb-1.0-0-dev \
     libnss3 \

--- a/scripts/build/docker/Dockerfile-armv7hf
+++ b/scripts/build/docker/Dockerfile-armv7hf
@@ -3,10 +3,6 @@ FROM resin/armv7hf-debian:jessie
 # Setup APT sources
 
 
-
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
-
-
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \

--- a/scripts/build/docker/Dockerfile-armv7hf
+++ b/scripts/build/docker/Dockerfile-armv7hf
@@ -31,6 +31,7 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    software-properties-common \
     unzip \
     xorriso \
     xvfb \

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -20,7 +20,7 @@ RUN apt-get update \
     jq \
     libasound2 \
     libgconf-2-4 \
-    libgtk3.0-0 \
+    libgtk-3-0 \
     libudev-dev \
     libusb-1.0-0-dev \
     libnss3 \

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -1,4 +1,4 @@
-FROM erwinchang/ubuntu-12.04-32bit-build
+FROM erwinchang/ubuntu-14.04-32bit-build
 
 # Setup APT sources
 

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -20,7 +20,7 @@ RUN apt-get update \
     jq \
     libasound2 \
     libgconf-2-4 \
-    libgtk2.0-0 \
+    libgtk3.0-0 \
     libudev-dev \
     libusb-1.0-0-dev \
     libnss3 \

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -1,4 +1,4 @@
-FROM erwinchang/ubuntu-14.04-32bit-build
+FROM erwinchang/ubuntu-14.04-32bit
 
 # Setup APT sources
 

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -32,6 +32,7 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    software-properties-common \
     unzip \
     xorriso \
     xvfb \

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -6,8 +6,6 @@ RUN sed s,ubuntu\.stu\.edu\.tw,archive.ubuntu.com, /etc/apt/sources.list > /tmp/
   && mv /tmp/sources.list /etc/apt/sources.list
 
 
-
-
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
@@ -50,12 +48,6 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-
-# Workaround: Install a newer version of `tar` to make fpm in electron-builder work again
-RUN echo "deb http://ftp.debian.org/debian wheezy main" >> /etc/apt/sources.list
-RUN echo "deb http://ftp.debian.org/debian wheezy-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install --force-yes -y -t wheezy libacl1 && \
-  apt-get install --force-yes -y -t wheezy-backports tar
 
 
 

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -1,4 +1,4 @@
-FROM erwinchang/ubuntu-14.04-32bit
+FROM i386/ubuntu:14.04
 
 # Setup APT sources
 

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -19,7 +19,7 @@ RUN apt-get update \
     jq \
     libasound2 \
     libgconf-2-4 \
-    libgtk2.0-0 \
+    libgtk3.0-0 \
     libudev-dev \
     libusb-1.0-0-dev \
     libnss3 \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -19,7 +19,7 @@ RUN apt-get update \
     jq \
     libasound2 \
     libgconf-2-4 \
-    libgtk3.0-0 \
+    libgtk-3-0 \
     libudev-dev \
     libusb-1.0-0-dev \
     libnss3 \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 # Setup APT sources
 

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -3,10 +3,6 @@ FROM ubuntu:14.04
 # Setup APT sources
 
 
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
-
-
-
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
@@ -49,12 +45,6 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-
-# Workaround: Install a newer version of `tar` to make fpm in electron-builder work again
-RUN echo "deb http://ftp.debian.org/debian wheezy main" >> /etc/apt/sources.list
-RUN echo "deb http://ftp.debian.org/debian wheezy-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install --force-yes -y -t wheezy libacl1 && \
-  apt-get install --force-yes -y -t wheezy-backports tar
 
 
 

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -31,6 +31,7 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    software-properties-common \
     unzip \
     xorriso \
     xvfb \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -24,7 +24,7 @@ RUN apt-get update \
     jq \
     libasound2 \
     libgconf-2-4 \
-    libgtk2.0-0 \
+    libgtk3.0-0 \
     libudev-dev \
     libusb-1.0-0-dev \
     libnss3 \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -24,7 +24,7 @@ RUN apt-get update \
     jq \
     libasound2 \
     libgconf-2-4 \
-    libgtk3.0-0 \
+    libgtk-3-0 \
     libudev-dev \
     libusb-1.0-0-dev \
     libnss3 \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -36,6 +36,7 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    software-properties-common \
     unzip \
     xorriso \
     xvfb \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -5,12 +5,6 @@ FROM <%= image %>
 RUN sed s,ubuntu\.stu\.edu\.tw,archive.ubuntu.com, /etc/apt/sources.list > /tmp/sources.list \
   && mv /tmp/sources.list /etc/apt/sources.list
 <% } %>
-<% if (architecture == 'x86_64') { %>
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
-<% } %>
-<% if (architecture == 'armv7hf') { %>
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
-<% } %>
 
 # Install dependencies
 RUN apt-get update \
@@ -54,12 +48,6 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-
-# Workaround: Install a newer version of `tar` to make fpm in electron-builder work again
-RUN echo "deb http://ftp.debian.org/debian wheezy main" >> /etc/apt/sources.list
-RUN echo "deb http://ftp.debian.org/debian wheezy-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install --force-yes -y -t wheezy libacl1 && \
-  apt-get install --force-yes -y -t wheezy-backports tar
 
 <% } %>
 

--- a/scripts/build/docker/compile-template.js
+++ b/scripts/build/docker/compile-template.js
@@ -31,11 +31,11 @@ const template = fs.readFileSync(path.join(currentDirectory, 'Dockerfile.templat
 _.each([
   {
     architecture: 'i686',
-    image: 'erwinchang/ubuntu-12.04-32bit-build'
+    image: 'erwinchang/ubuntu-14.04-32bit-build'
   },
   {
     architecture: 'x86_64',
-    image: 'ubuntu:12.04'
+    image: 'ubuntu:14.04'
   },
   {
     architecture: 'armv7hf',

--- a/scripts/build/docker/compile-template.js
+++ b/scripts/build/docker/compile-template.js
@@ -31,7 +31,7 @@ const template = fs.readFileSync(path.join(currentDirectory, 'Dockerfile.templat
 _.each([
   {
     architecture: 'i686',
-    image: 'erwinchang/ubuntu-14.04-32bit'
+    image: 'i386/ubuntu:14.04'
   },
   {
     architecture: 'x86_64',

--- a/scripts/build/docker/compile-template.js
+++ b/scripts/build/docker/compile-template.js
@@ -31,7 +31,7 @@ const template = fs.readFileSync(path.join(currentDirectory, 'Dockerfile.templat
 _.each([
   {
     architecture: 'i686',
-    image: 'erwinchang/ubuntu-14.04-32bit-build'
+    image: 'erwinchang/ubuntu-14.04-32bit'
   },
   {
     architecture: 'x86_64',


### PR DESCRIPTION
**TODO**

- [x] resolve Webview related error
- [x] resolve "electron: error while loading shared libraries: libgtk-3.so.0: cannot open shared object file: No such file or directory" on linux / up2
- [x] https://github.com/resin-io/etcher/pull/2412
- [x] resolve "/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.17' not found (required by /etcher/node_modules/electron/dist/electron)"
- [ ] Update [resin-ci/pipelines/electron/docker](https://github.com/resin-io/resin-concourse/tree/master/pipelines/electron/docker) according to Dockerfile changes

Change-Type: patch
Connects To: #2165 