### PR TITLE
docs: Add info about required npm version

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Developing
 - [Python 2.7](https://www.python.org)
 - [jq](https://stedolan.github.io/jq/)
 - [curl](https://curl.haxx.se/)
+- [npm](https://www.npmjs.com/) (version 3.10)
 
 ```sh
 pip install -r requirements.txt

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Developing
 
 #### Common
 
-- [NodeJS](https://nodejs.org) (at least v6)
+- [NodeJS](https://nodejs.org) (at least v6.11)
 - [Python 2.7](https://www.python.org)
 - [jq](https://stedolan.github.io/jq/)
 - [curl](https://curl.haxx.se/)


### PR DESCRIPTION
npm 3.10 version is required to install dev tools correctly on Linux.

Change-type: patch
Signed-off-by: amdomanska <aga@resin.io>