### PR TITLE
docs(support): Move support.md file to docs folder

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,34 @@
+Getting help with Etcher
+========================
+
+There are various ways to get support for Etcher if you experience an issue or
+have an idea you'd like to share with us.
+
+Forums
+------
+
+We have a [Discourse forum][discourse] which is open to everyone, so please
+come join us :). Drop us a line there and the resin.io staff and community
+users will be happy to assist. Your question might already be answered, so take
+a look at the existing threads before opening a new one!
+
+Make sure to mention the following information to help us provide better
+support:
+
+- The Etcher version you're running.
+
+- The operating system you're running Etcher in.
+
+- Relevant logging output, if any, from DevTools, which you can open by
+  pressing `Ctrl+Shift+I` or `Cmd+Alt+I` depending on your platform.
+
+GitHub
+------
+
+If you encounter an issue or have a suggestion, head on over to Etcher's [issue
+tracker][issues] and if there isn't a ticket covering it, [create
+one][new-issue].
+
+[discourse]: https://forums.resin.io/c/etcher
+[issues]: https://github.com/resin-io/etcher/issues
+[new-issue]: https://github.com/resin-io/etcher/issues/new


### PR DESCRIPTION
For new webpage support.md support.md file needs to be moved. As long as the old homepage is accessible both copies of the file need to be kept but once the new homepage will be published the old copy should be removed 

Change-type: patch
Signed-off-by: amdomanska <aga@resin.io>