### PR TITLE
fix(GUI): Fix update notification error

### DIFF
--- a/lib/gui/app/components/update-notifier.js
+++ b/lib/gui/app/components/update-notifier.js
@@ -79,7 +79,7 @@ exports.shouldCheckForUpdates = (options) => {
     return true
   }
 
-  return Date.now() - options.lastSleptUpdateNotifier > units.daysToMilliseconds(this.UPDATE_NOTIFIER_SLEEP_DAYS)
+  return Date.now() - options.lastSleptUpdateNotifier > units.daysToMilliseconds(exports.UPDATE_NOTIFIER_SLEEP_DAYS)
 }
 
 /**
@@ -117,7 +117,7 @@ exports.notify = (version, options = {}) => {
 
   if (_.get(options, [ 'allowSleepUpdateCheck' ], true)) {
     _.merge(dialogOptions, {
-      checkboxLabel: `Remind me again in ${this.UPDATE_NOTIFIER_SLEEP_DAYS} days`,
+      checkboxLabel: `Remind me again in ${exports.UPDATE_NOTIFIER_SLEEP_DAYS} days`,
       checkboxChecked: false
     })
   }


### PR DESCRIPTION
Remove "this" and use "exports" instead

Change-type: patch
Changelog-entry: Fix update notifier error popping up on v1.4.1->1.4.8
Signed-off-by: Lorenzo Alberto Maria Ambrosi <lorenzoa@balena.io>