### PR TITLE
Updated Chocolatey section of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,19 @@ brew cask install etcher
 brew cask uninstall etcher
 ```
 
-### Chocolatey (Windows)
+#### Chocolatey (Windows)
 
 This package is maintained by [@majkinetor](https://github.com/majkinetor), and
 is kept up to date automatically.
 
 ```sh
 choco install etcher
+```
+
+##### Uninstall
+
+```
+choco uninstall etcher
 ```
 
 Support


### PR DESCRIPTION
Previously, the section header was a level 3 header, and I changed it to a lever 4 header like all the other install variants so it is the same level header. I also added uninstall instructions like the other sections had.