### PR TITLE
Add `.wic` image extension as supported format

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -45,5 +45,6 @@ Makefile text
 *.bin binary diff=hex
 *.dmg binary diff=hex
 *.rpi-sdcard binary diff=hex
+*.wic binary diff=hex
 *.foo binary diff=hex
 xz-without-extension binary diff=hex

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ lint-spell:
 	codespell \
 		--dictionary - \
 		--dictionary dictionary.txt \
-		--skip *.svg *.gz,*.bz2,*.xz,*.zip,*.img,*.dmg,*.iso,*.rpi-sdcard,.DS_Store,*.dtb,*.dtbo,*.dat,*.elf,*.bin,*.foo,xz-without-extension \
+		--skip *.svg *.gz,*.bz2,*.xz,*.zip,*.img,*.dmg,*.iso,*.rpi-sdcard,*.wic,.DS_Store,*.dtb,*.dtbo,*.dat,*.elf,*.bin,*.foo,xz-without-extension \
 		lib tests docs scripts Makefile *.md LICENSE
 
 lint: lint-js lint-sass lint-cpp lint-html lint-spell

--- a/lib/sdk/image-stream/supported.js
+++ b/lib/sdk/image-stream/supported.js
@@ -80,5 +80,9 @@ module.exports = [
   {
     extension: 'rpi-sdimg',
     type: 'image'
+  },
+  {
+    extension: 'wic',
+    type: 'image'
   }
 ]

--- a/tests/shared/supported-formats.spec.js
+++ b/tests/shared/supported-formats.spec.js
@@ -31,7 +31,9 @@ describe('Shared: SupportedFormats', function () {
   describe('.getNonCompressedExtensions()', function () {
     it('should return the supported non compressed extensions', function () {
       const extensions = supportedFormats.getNonCompressedExtensions()
-      m.chai.expect(extensions).to.deep.equal([ 'img', 'iso', 'bin', 'dsk', 'hddimg', 'raw', 'dmg', 'sdcard', 'rpi-sdimg' ])
+      m.chai.expect(extensions).to.deep.equal([
+        'img', 'iso', 'bin', 'dsk', 'hddimg', 'raw', 'dmg', 'sdcard', 'rpi-sdimg', 'wic'
+      ])
     })
   })
 
@@ -72,7 +74,8 @@ describe('Shared: SupportedFormats', function () {
       'path/to/filename.hddimg',
       'path/to/filename.raw',
       'path/to/filename.dmg',
-      'path/to/filename.sdcard'
+      'path/to/filename.sdcard',
+      'path/to/filename.wic'
 
     ], (filename) => {
       it(`should return true for ${filename}`, function () {


### PR DESCRIPTION
The `.wic` is a widely used image format in the OpenEmbedded / Yocto
Project ecosystem and is straightforward to be supported.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>