### PR TITLE
Change "Drive Contains Image" label.

### DIFF
--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -97,7 +97,7 @@ module.exports = {
     },
 
     containsImage () {
-      return 'Drive Contains Image'
+      return 'Drive Mountpoint Contains Image'
     },
 
     // The drive is large and therefore likely not a medium you want to write to.

--- a/tests/shared/drive-constraints.spec.js
+++ b/tests/shared/drive-constraints.spec.js
@@ -1322,7 +1322,7 @@ describe('Shared: DriveConstraints', function () {
       it('should return contains image error', function () {
         m.chai.expect(constraints.getListDriveImageCompatibilityStatuses([ drives[0] ], image)).to.deep.equal([
           {
-            message: 'Drive Contains Image',
+            message: 'Drive Mountpoint Contains Image',
             type: 2
           }
         ])
@@ -1378,7 +1378,7 @@ describe('Shared: DriveConstraints', function () {
       it('should return all statuses', function () {
         m.chai.expect(constraints.getListDriveImageCompatibilityStatuses(drives, image)).to.deep.equal([
           {
-            message: 'Drive Contains Image',
+            message: 'Drive Mountpoint Contains Image',
             type: 2
           },
           {


### PR DESCRIPTION
Use "Drive Mountpoint Contains Image" instead as the image may not be on
this drive but on a drive mounted in one of the mountpoins of this
drive.
We still don't want to allow flashing this drive in that situation.

Change-type: patch

Connects-To: #2281 