### PR TITLE
Update electron links

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Etcher is free software, and may be redistributed under the terms specified in
 the [license].
 
 [etcher]: https://balena.io/etcher
-[electron]: http://electron.atom.io
-[electron-supported-platforms]: http://electron.atom.io/docs/tutorial/supported-platforms/
+[electron]: https://electronjs.org/
+[electron-supported-platforms]: https://electronjs.org/docs/tutorial/support#supported-platforms
 [SUPPORT]: https://github.com/balena-io/etcher/blob/master/SUPPORT.md
 [CONTRIBUTING]: https://github.com/balena-io/etcher/blob/master/docs/CONTRIBUTING.md
 [USER-DOCUMENTATION]: https://github.com/balena-io/etcher/blob/master/docs/USER-DOCUMENTATION.md


### PR DESCRIPTION
Original [link works](https://electronjs.org/docs/tutorial/supported-platforms), but the page says the it was moved to the support.md. This PR updates this link to the correct/working one:

* https://electronjs.org/docs/tutorial/support#supported-platforms

It also updates electron link to https://electronjs.org/

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>