### PR TITLE
Fix user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ was written correctly and much more.
 ## Supported Operating Systems
 
 - Linux (most distros)
-- macOS 10.9 and later
+- macOS 10.10 (Yosemite) and later
 - Microsoft Windows 7 and later
 
 Note that Etcher will run on any platform officially supported by

--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -213,8 +213,8 @@ macOS 10.9 and newer versions][electron-supported-platforms].
 [xwayland]: https://wayland.freedesktop.org/xserver.html
 [weston.ini]: http://manpages.ubuntu.com/manpages/wily/man5/weston.ini.5.html
 [diskpart]: https://technet.microsoft.com/en-us/library/cc770877(v=ws.11).aspx
-[electron]: http://electron.atom.io
-[electron-supported-platforms]: https://github.com/electron/electron/blob/master/docs/tutorial/supported-platforms.md
+[electron]: https://electronjs.org/
+[electron-supported-platforms]: https://electronjs.org/docs/tutorial/support#supported-platforms
 [publishing]: https://github.com/balena-io/etcher/blob/master/docs/PUBLISHING.md
 [windows-usb-tool]: https://www.microsoft.com/en-us/download/windows-usb-dvd-download-tool
 [rufus]: https://rufus.akeo.ie

--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -30,7 +30,7 @@ if you require this functionality, we advise to fallback to
 Deactivate desktop shortcut prompt on GNU/Linux
 -----------------------------------------------
 
-This is a feature provided by [AppImages](appimage), where the applications
+This is a feature provided by [AppImages][appimage], where the applications
 prompts the user to automatically register a desktop shortcut to easily access
 the application.
 

--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -206,7 +206,7 @@ Running in older macOS versions
 -------------------------------
 
 Etcher GUI is based on the [Electron][electron] framework, [which only supports
-macOS 10.9 and newer versions][electron-supported-platforms].
+macOS 10.10 (Yosemite) and newer versions][electron-supported-platforms].
 
 [balena.io]: https://balena.io
 [appimage]: http://appimage.org


### PR DESCRIPTION
* Same electron link updates as in #2651
* According to [this page](https://electronjs.org/docs/tutorial/support#macos), macOS 10.10 (Yosemite) is required, not macOS 10.9