### PR TITLE
Fix disappearing modal

### DIFF
--- a/lib/gui/app/components/modal/services/modal.js
+++ b/lib/gui/app/components/modal/services/modal.js
@@ -56,7 +56,8 @@ module.exports = function ($uibModal, $q) {
       template: options.template,
       controller: options.controller,
       size: options.size,
-      resolve: options.resolve
+      resolve: options.resolve,
+      backdrop: 'static'
     })
 
     return {
@@ -73,7 +74,7 @@ module.exports = function ($uibModal, $q) {
           resolve(value)
         }).catch((error) => {
           // Bootstrap doesn't 'resolve' these but cancels the dialog
-          if (error === 'escape key press' || error === 'backdrop click') {
+          if (error === 'escape key press') {
             analytics.logEvent('Modal rejected', {
               name: options.name,
               method: error,


### PR DESCRIPTION
It fixes #2648 for me. Based on [this](https://getbootstrap.com/docs/3.3/javascript/#modals-options).

> Includes a modal-backdrop element. Alternatively, specify `static` for a backdrop which doesn't close the modal on click.

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>