### PR TITLE
Target electron 3 runtime in babel options

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,10 @@ const commonConfig = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: [ '@babel/preset-react', '@babel/preset-env' ],
+            presets: [
+              '@babel/preset-react',
+              [ '@babel/preset-env', { targets: { electron: '3' } } ]
+            ],
             plugins: [ '@babel/plugin-proposal-function-bind' ],
             cacheDirectory: true
           }


### PR DESCRIPTION
This saves around 40KiB in generated/gui.js

Changelog-entry: Target electron 3 runtime in babel options
Change-type: patch