### PR TITLE
Set publishMetadata in repo.yml

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,5 +1,6 @@
 type: electron
 release: github
+publishMetadata: true
 sentry:
     org: balenaetcher
     team: resinio


### PR DESCRIPTION
This will cause VB to publish metadata about the repo to its gh-pages
branch on merge

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>