### PR TITLE
Use full path to wmic as some systems don't have it in their PATH

### DIFF
--- a/lib/gui/app/os/windows-network-drives.js
+++ b/lib/gui/app/os/windows-network-drives.js
@@ -19,6 +19,8 @@
 const cp = require('child_process')
 const _ = require('lodash')
 const os = require('os')
+const path = require('path')
+const process = require('process')
 
 /**
  * @summary Promisified child_process.execFile
@@ -63,7 +65,7 @@ const execFileAsync = async (file, args, options) => {
  */
 const getWindowsNetworkDrives = async () => {
   const result = await execFileAsync(
-    'wmic',
+    path.join(process.env.SystemRoot, 'System32', 'Wbem', 'wmic'),
     [ 'path', 'Win32_LogicalDisk', 'Where', 'DriveType="4"', 'get', 'DeviceID,ProviderName' ],
     { windowsHide: true, windowsVerbatimArguments: true }
   )

--- a/tests/gui/os/windows-network-drives.spec.js
+++ b/tests/gui/os/windows-network-drives.spec.js
@@ -20,6 +20,7 @@ const { readFile } = require('fs')
 const os = require('os')
 const cp = require('child_process')
 const m = require('mochainon')
+const { env } = require('process')
 const { promisify } = require('util')
 
 const { replaceWindowsNetworkDriveLetter } = require('../../../lib/gui/app/os/windows-network-drives')
@@ -33,6 +34,8 @@ describe('Network drives on Windows', () => {
     const wmicOutput = await readFileAsync('tests/data/wmic-output.txt', { encoding: 'ucs2' })
     this.execFileStub = m.sinon.stub(cp, 'execFile')
     this.execFileStub.callsArgWith(3, null, wmicOutput)
+    this.oldSystemRoot = env.SystemRoot
+    env.SystemRoot = 'C:\\Windows'
   })
 
   it('should parse network drive mapping on Windows', async () => {
@@ -43,5 +46,6 @@ describe('Network drives on Windows', () => {
   after(() => {
     this.osPlatformStub.restore()
     this.execFileStub.restore()
+    env.SystemRoot = this.oldSystemRoot
   })
 })


### PR DESCRIPTION
Changelog-entry: (Windows): Use full path to wmic as some systems don't have it in their PATH
Change-type: patch