### PR TITLE
Update etcher-sdk to ^2.0.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5273,9 +5273,9 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etcher-sdk": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-2.0.3.tgz",
-      "integrity": "sha512-Ix+d7czuIMXyjCztmqD75iJdAY4b17HdLhMDjXd5vLUhWdq/qBPkjyuNn1TZosyrEyZ+hoe3+ZOSLjLFL2GHLA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-2.0.5.tgz",
+      "integrity": "sha512-222NEcUeKQqvBf0rPL0mmuEIuxpuQpmMSZRLv3mCXsOT4/cgtYPbwQAlEtTbRPRbFMfyO+7yhwf20PXgfhU5/A==",
       "requires": {
         "@types/node": "^6.0.112",
         "axios": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "debug": "^3.1.0",
     "electron-is-running-in-asar": "^1.0.0",
     "electron-updater": "4.0.6",
-    "etcher-sdk": "^2.0.3",
+    "etcher-sdk": "^2.0.5",
     "flexboxgrid": "^6.3.0",
     "immutable": "^3.8.1",
     "inactivity-timer": "^1.0.0",


### PR DESCRIPTION
Changelog-entry: Fix gzipped files verification percentage and dmg verification.
Change-type: patch