### PR TITLE
Including Arch / Manjaro install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ sudo eopkg it etcher
 sudo eopkg rm etcher
 ```
 
+#### Arch Linux / Manjaro (GNU/Linux x64)
+
+Etcher is offered through the Arch User Repository and can be installed on both Manjaro and Arch systems. You can compile it from the source code in this repository using [`balena-etcher`](https://aur.archlinux.org/packages/balena-etcher/) or use the latest release with [`etcher-bin`](https://aur.archlinux.org/packages/etcher-bin/). The following example uses a common AUR helper to install the latest release:
+
+
+```sh
+yay -S etcher-bin
+```
+
+##### Uninstall
+
+```sh
+yay -R etcher-bin
+```
+
 #### Brew Cask (macOS)
 
 Note that the Etcher Cask has to be updated manually to point to new versions,


### PR DESCRIPTION
This tool has been useful for many users, and the Arch Wiki itself references it under its page for [flashing USB installation media](https://wiki.archlinux.org/index.php/USB_flash_installation_media#Using_etcher). I figured this could use install instructions for `pacman`-oriented distributions.