### PR TITLE
correct two nomenclature errors, redux

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,4 +3,4 @@
 - **Image flashed:** 
 - **Do you see any meaningful error information in the DevTools?** 
 
-<!-- You can open DevTools by pressing `Ctrl+Shift+I` (`Ctrl+Alt+I` for Etcher before v1.3.x), or `Cmd+Alt+I` if you're on Mac OS. -->
+<!-- You can open DevTools by pressing `Ctrl+Shift+I` (`Ctrl+Alt+I` for Etcher before v1.3.x), or `Cmd+Opt+I` if you're on macOS. -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,4 +3,4 @@
 - **Image flashed:** 
 - **Do you see any meaningful error information in the DevTools?** 
 
-<!-- You can open DevTools by pressing `Ctrl+Shift+I` (`Ctrl+Alt+I` for Etcher before v1.3.x), or `Cmd+Opt+I` if you're on macOS. -->
+<!-- You can open DevTools by pressing `Ctrl+Shift+I` (`Ctrl+Alt+I` for Etcher before v1.3.x), or `Cmd+Opt+I` if you're on macOS.


### PR DESCRIPTION
correct two nomenclature errors

PC keyboards have "Alt" keys; Mac keyboards have "Opt" keys. Although it's possible to use a PC keyboard on a Mac, it's unusual. In any case, all of the macOS (not "Mac OS" for some years now) documentation refers to the "Opt" key.

Change-type: minor
Changelog-entry: correct two nomenclature errors