### PR TITLE
Use bash instead of sh for running the elevated process on Linux and Mac

### DIFF
--- a/lib/shared/permissions.js
+++ b/lib/shared/permissions.js
@@ -148,7 +148,7 @@ const elevateScriptWindows = async (path) => {
 }
 
 const elevateScriptUnix = async (path, name) => {
-  const cmd = [ 'sh', escapeSh(path) ].join(' ')
+  const cmd = [ 'bash', escapeSh(path) ].join(' ')
   const [ , stderr ] = await sudoPrompt.execAsync(cmd, { name })
   if (!_.isEmpty(stderr)) {
     throw errors.createError({ title: stderr })
@@ -157,7 +157,7 @@ const elevateScriptUnix = async (path, name) => {
 }
 
 const elevateScriptCatalina = async (path) => {
-  const cmd = [ 'sh', escapeSh(path) ].join(' ')
+  const cmd = [ 'bash', escapeSh(path) ].join(' ')
   try {
     const { cancelled } = await catalinaSudo(cmd)
     return { cancelled }


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Use bash instead of sh for running the elevated process on Linux and Mac
Related to #2970 