### PR TITLE
Update GPG key acquisition to work on Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ installers for all supported operating systems.
 2. Trust Bintray.com's GPG key:
 
     ```sh
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
     ```
 
 3. Update and install:


### PR DESCRIPTION
The former command failed systematically, the keyserver did not respond.
This modified command did the trick