### PR TITLE
Update drivelist to 8.0.10 to fix parsing lsblk --pairs

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4299,9 +4299,9 @@
       "dev": true
     },
     "drivelist": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-8.0.9.tgz",
-      "integrity": "sha512-s25SFYuMDD7WK+/CaOZpXCXCpBU0aJwBwGlg0AkO8ttVTIGEJSdBgjQQdBFeR0Z9Pl/BRGst7YIScv4q2LLo6w==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-8.0.10.tgz",
+      "integrity": "sha512-2A/NCMn9jQ/9J1B8zohS8rnXQKDM6ZixLAlYS/rBeZV2NuSXJCMr/M8kKdr4vy95oOxKXi8NXk+IVrHCS3bung==",
       "requires": {
         "bindings": "^1.3.0",
         "debug": "^3.1.0",


### PR DESCRIPTION
Changelog-entry: Update drivelist to 8.0.10 to fix parsing lsblk --pairs
Change-type: patch