### PR TITLE
Fix error on launch from terminal when installed via apt 

### DIFF
--- a/afterPack.js
+++ b/afterPack.js
@@ -14,12 +14,16 @@ exports.default = function(context) {
   cp.execFileSync('mv', [scriptPath, binPath])
   fs.writeFileSync(
     scriptPath,
-    outdent`
+    outdent({trimTrailingNewline: false})`
       #!/bin/bash
+
+      # Resolve symlinks. Warning, readlink -f doesn't work on MacOS/BSD
+      script_dir="$(dirname "$(readlink -f "\${BASH_SOURCE[0]}")")"
+
       if [[ $EUID -ne 0 ]] || [[ $ELECTRON_RUN_AS_NODE ]]; then
-        "\${BASH_SOURCE%/*}"/${context.packager.executableName}.bin "$@"
+        "\${script_dir}"/${context.packager.executableName}.bin "$@"
       else
-        "\${BASH_SOURCE%/*}"/${context.packager.executableName}.bin "$@" --no-sandbox
+        "\${script_dir}"/${context.packager.executableName}.bin "$@" --no-sandbox
       fi
     `
   )


### PR DESCRIPTION
Fixes https://github.com/balena-io/etcher/issues/3074

When installing balena-etcher via apt on Debian/Ubuntu,
the command `balena-etcher-electron` fails with the error:

```console
alois@ubuntu:~$ balena-etcher-electron
/usr/bin/balena-etcher-electron: line 3: /usr/bin/balena-etcher-electron.bin: No such file or directory
```

This is because the `/usr/bin/balena-etcher-electron` is a symlink
to `/opt/balenaEtcher/balena-etcher-electron`, but the script looks
for `balena-etcher-electron.bin` in the symlink directory, not the
actual script location directory.

This commit uses `$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")` to
find the real location of the `balena-etcher-electron` script without
symlink, so that `balena-etcher-electron.bin` is correctly found.

The `balena-etcher-electron` script created by afterPack.js looks like:

```bash
#!/bin/bash

# Resolve symlinks. Warning, readlink -f doesn't work on MacOS/BSD
script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"

if [[ $EUID -ne 0 ]] || [[ $ELECTRON_RUN_AS_NODE ]]; then
  "${script_dir}"/balena-etcher-electron.bin "$@"
else
  "${script_dir}"/balena-etcher-electron.bin "$@" --no-sandbox
fi
```

## Testing

I ran `npx run electron-builder`, and confirmed that the script in `etcher/dist/linux-unpacked/balena-etcher-electron` works correctly when symlinked to `/usr/bin/balena-etcher-electron`, on my Ubuntu 19.04 machine. Unfortunately, I'm not sure how the `.deb` file is built, so I haven't tested creating one.