### PR TITLE
README: adapt gpg key acquisition to work on Ubuntu18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ installers for all supported operating systems.
 2. Trust Bintray.com's GPG key:
 
     ```sh
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
+    sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 379CE192D401AB61
     ```
 
 3. Update and install:


### PR DESCRIPTION
The former command failed systematically, the keyserver did not respond.
This modified command did the trick, using hkps.
(Follows https://github.com/balena-io/etcher/pull/3069 that was closed 
for not using hkps)