### PR TITLE
Update Manjaro instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# v1.5.85
+## (2020-05-05)
+
+* Prefer balena-etcher to etcher-bin on Arch Linux [Alexis Svinartchouk]
+
 # v1.5.84
 ## (2020-05-04)
 

--- a/README.md
+++ b/README.md
@@ -122,17 +122,17 @@ sudo eopkg rm etcher
 
 #### Arch Linux / Manjaro (GNU/Linux x64)
 
-Etcher is offered through the Arch User Repository and can be installed on both Manjaro and Arch systems. You can compile it from the source code in this repository using [`balena-etcher`](https://aur.archlinux.org/packages/balena-etcher/) or use the latest release with [`etcher-bin`](https://aur.archlinux.org/packages/etcher-bin/). The following example uses a common AUR helper to install the latest release:
+Etcher is offered through the Arch User Repository and can be installed on both Manjaro and Arch systems. You can compile it from the source code in this repository using [`balena-etcher`](https://aur.archlinux.org/packages/balena-etcher/). The following example uses a common AUR helper to install the latest release:
 
 
 ```sh
-yay -S etcher-bin
+yay -S balena-etcher
 ```
 
 ##### Uninstall
 
 ```sh
-yay -R etcher-bin
+yay -R balena-etcher
 ```
 
 #### Brew Cask (macOS)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "balena-etcher",
-  "version": "1.5.84",
+  "version": "1.5.85",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "balena-etcher",
   "private": true,
   "displayName": "balenaEtcher",
-  "version": "1.5.84",
+  "version": "1.5.85",
   "packageType": "local",
   "main": "generated/etcher.js",
   "description": "Flash OS images to SD cards and USB drives, safely and easily.",


### PR DESCRIPTION
Manjaro maintains etcher in their community repository (https://gitlab.manjaro.org/packages/community/etcher) 

Therefore all one needs to do on Manjaro to install etcher is the normal `sudo pacman -S etcher` , no need to use yay and get it from the AUR. 

My bad, did not mean to request those two commits to be merged. 