### PR TITLE
Init param in correct place

### DIFF
--- a/lib/shared/drive-constraints.ts
+++ b/lib/shared/drive-constraints.ts
@@ -58,8 +58,10 @@ export interface Image {
  * In the context of Etcher, a source drive is a drive
  * containing the image.
  */
-export function isSourceDrive(drive: DrivelistDrive, image: Image): boolean {
-	image = image || {};
+export function isSourceDrive(
+	drive: DrivelistDrive,
+	image: Image = {},
+): boolean {
 	for (const mountpoint of drive.mountpoints || []) {
 		if (image.path !== undefined && pathIsInside(image.path, mountpoint.path)) {
 			return true;


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Minor fix - Init isSourceDrive param in correct place
Signed-off-by: Lorenzo Alberto Maria Ambrosi <lorenzothunder.ambrosi@gmail.com>