### PR TITLE
Add custom protocol

### DIFF
--- a/.resinci.json
+++ b/.resinci.json
@@ -63,7 +63,7 @@
         ]
       },
       "protocols": {
-        "name": "etcher-protocol",
+        "name": "etcher",
         "schemes": [
           "etcher"
         ]

--- a/.resinci.json
+++ b/.resinci.json
@@ -61,6 +61,12 @@
         "depends": [
           "polkit-1-auth-agent | policykit-1-gnome | polkit-kde-1"
         ]
+      },
+      "protocols": {
+        "name": "etcher-protocol",
+        "schemes": [
+          "etcher"
+        ]
       }
     }
   }

--- a/afterSignHook.js
+++ b/afterSignHook.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const { notarize } = require('electron-notarize')
+const { ELECTRON_SKIP_NOTARIZATION } = process.env
 
 async function main(context) {
   const { electronPlatformName, appOutDir } = context
-  if (electronPlatformName !== 'darwin') {
+  if (electronPlatformName !== 'darwin' || ELECTRON_SKIP_NOTARIZATION === 'true') {
     return
   }
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -90,3 +90,7 @@ deb:
 rpm:
   depends:
     - util-linux
+protocols:
+  name: etcher-protocol
+  schemes:
+    - etcher

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -91,6 +91,6 @@ rpm:
   depends:
     - util-linux
 protocols:
-  name: etcher-protocol
+  name: etcher
   schemes:
     - etcher


### PR DESCRIPTION
This will enable etcher to be opened and pre-select an image through both command-line arguments (first argument after the executable) and links such as:

`etcher://https://resin-staging-img.s3.amazonaws.com/images/artik10/2.3.0%2Brev1.dev/image/resin.img.zip`

Fixes: https://github.com/balena-io/etcher/issues/2742