### PR TITLE
Makefile: Don't hardcode npm version in NPM_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------
 
 RESIN_SCRIPTS ?= ./scripts/resin
-export NPM_VERSION ?= 6.14.5
+export NPM_VERSION ?= $(shell npm --version)
 S3_BUCKET = artifacts.ci.balena-cloud.com
 
 # This directory will be completely deleted by the `clean` rule


### PR DESCRIPTION
We can fetch it (and looks like we should) dynamically from the system
instead, so that the user doesn't need to remember to manually pass it
everytime.

Change-type: patch