### PR TITLE
spectron: Make tests pass on Windows Docker containers

### DIFF
--- a/tests/spectron/runner.spec.ts
+++ b/tests/spectron/runner.spec.ts
@@ -51,7 +51,14 @@ describe('Spectron', function () {
 
 	describe('Browser Window', function () {
 		it('should open a browser window', async function () {
-			return expect(await app.browserWindow.isVisible()).to.be.true;
+			// We can't use `isVisible()` here as it won't work inside
+			// a Windows Docker container, but we can approximate it
+			// with these set of checks:
+			const bounds = await app.browserWindow.getBounds();
+			expect(bounds.height).to.be.above(0);
+			expect(bounds.width).to.be.above(0);
+			expect(await app.browserWindow.isMinimized()).to.be.false;
+			expect(await app.browserWindow.isFocused()).to.be.true;
 		});
 
 		it('should set a proper title', async function () {


### PR DESCRIPTION
The Spectron test that we have that checks that the browser window is
visible fails when ran inside a Windows Docker container.

In particular, the `isVisible()` function returns `false` when running
in a headless Windows machine.

However, the `isMinimized()` function returns `false`, the `isFocused()`
function returns `true`, and we can fetch the expected browser window
bounds, so we can use all those values in conjunction to reformulate the
test case and avoid `isVisible()`.

The results should be pretty much the same, and the assertions will pass
inside Docker Windows containers.

Change-type: patch