### PR TITLE
Updates Etcher to build on balenaCI v6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------
 
 RESIN_SCRIPTS ?= ./scripts/resin
-export NPM_VERSION ?= 6.14.5
+export NPM_VERSION ?= 6.14.8
 S3_BUCKET = artifacts.ci.balena-cloud.com
 
 # This directory will be completely deleted by the `clean` rule

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Etcher
 
+
 > Flash OS images to SD cards & USB drives, safely and easily.
 
 Etcher is a powerful OS image flasher built with web technologies to ensure

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "webpack": "webpack",
     "watch": "webpack --watch",
     "concourse-build-electron": "npm run webpack",
-    "concourse-test": "npx npm@6.14.5 test",
-    "concourse-test-electron": "npx npm@6.14.5 test"
+    "concourse-test": "npx npm@6.14.8 test",
+    "concourse-test-electron": "npx npm@6.14.8 test"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
** do not ** merge until balenaCI is migrated fully to Concourse v6 PR

    Makes balena-cli build on refreshed on-prem workers
    
    * Bump npm version
    
    Change-type: patch