### PR TITLE
Linked

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10046,6 +10046,15 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "pnp-webpack-plugin": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
+      "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
+      "dev": true,
+      "requires": {
+        "ts-pnp": "^1.1.6"
+      }
+    },
     "polished": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.0.tgz",
@@ -12581,6 +12590,12 @@
         "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       }
+    },
+    "ts-pnp": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
+      "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
+      "dev": true
     },
     "tslib": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "omit-deep-lodash": "1.1.4",
     "outdent": "^0.7.1",
     "path-is-inside": "^1.0.2",
+    "pnp-webpack-plugin": "^1.6.4",
     "pretty-bytes": "^5.3.0",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
@@ -120,6 +121,5 @@
     "uuid": "^8.1.0",
     "webpack": "^5.11.0",
     "webpack-cli": "^4.2.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/typings/pnp-webpack-plugin/index.d.ts
+++ b/typings/pnp-webpack-plugin/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'pnp-webpack-plugin';

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -25,6 +25,7 @@ import { env } from 'process';
 import * as SimpleProgressWebpackPlugin from 'simple-progress-webpack-plugin';
 import * as TerserPlugin from 'terser-webpack-plugin';
 import { BannerPlugin, NormalModuleReplacementPlugin } from 'webpack';
+import * as PnpWebpackPlugin from 'pnp-webpack-plugin';
 
 /**
  * Don't webpack package.json as mixpanel & sentry tokens
@@ -120,7 +121,7 @@ function fetchWasm(...where: string[]) {
 		} catch {
 		}
 		function appPath() {
-			return Path.isAbsolute(__dirname) ? 
+			return Path.isAbsolute(__dirname) ?
 				__dirname :
 				Path.join(
 					// With macOS universal builds, getAppPath() returns the path to an app.asar file containing an index.js file which will
@@ -289,6 +290,7 @@ const commonConfig = {
 		extensions: ['.node', '.js', '.json', '.ts', '.tsx'],
 	},
 	plugins: [
+		PnpWebpackPlugin,
 		new SimpleProgressWebpackPlugin({
 			format: process.env.WEBPACK_PROGRESS || 'verbose',
 		}),
@@ -299,6 +301,9 @@ const commonConfig = {
 			'./http.js',
 		),
 	],
+	resolveLoader: {
+		plugins: [PnpWebpackPlugin.moduleLoader(module)],
+	},
 	output: {
 		path: path.join(__dirname, 'generated'),
 		filename: '[name].js',


### PR DESCRIPTION
This change enables you to use `npm link` in order to build and push a local version of `etcher-sdk` (or any linked library) by using the [pnp](https://www.w3resource.com/yarn/getting-started-with-plug-n-play.php) module resolution algorithm rather than node's native module resolution