### PR TITLE
chore: replace make webpack with npm run webpack

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -91,7 +91,7 @@ make electron-develop
 
 ```sh
 # Build the GUI
-make webpack
+npm run webpack
 # Start Electron
 npm start
 ```


### PR DESCRIPTION
I was running through CONTRIBUTING.md and got tripped up by one of the instructions.

It seems to me this should be updated to `npm run`, instead of `make`?