### PR TITLE
Change Linux instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ confidence.
    sudo apt update
    sudo apt install balena-etcher
    ```
-   >Note: after v1.7.9 the package name changed to `balena-etcher` (no electron at the end)
+   >Note: for version 1.7.9 and below the package name was `balena-etcher-electron`
 
 ##### Uninstall
 
@@ -87,7 +87,7 @@ sudo apt autoremove
    ```sh
    sudo dnf install -y balena-etcher
    ```
-   >Note: after v1.7.9 the package name changed to `balena-etcher` (no electron at the end)
+   >Note: for version 1.7.9 and below the package name was `balena-etcher-electron`
 
 ###### Uninstall
 
@@ -112,7 +112,7 @@ rm /etc/yum.repos.d/balena-etcher-source.repo
    ```sh
    sudo yum install -y balena-etcher
    ```
-   >Note: after v1.7.9 the package name changed to `balena-etcher` (no electron at the end)
+   >Note: for version 1.7.9 and below the package name was `balena-etcher-electron`
 
 ###### Uninstall
 
@@ -137,7 +137,7 @@ rm /etc/yum.repos.d/balena-etcher-source.repo
    sudo zypper up
    sudo zypper install balena-etcher
    ```
-   >Note: after v1.7.9 the package name changed to `balena-etcher` (no electron at the end)
+   >Note: for version 1.7.9 and below the package name was `balena-etcher-electron`
 
 ##### Uninstall
 


### PR DESCRIPTION
1. `apt` is better for installations and is more use than `apt-get`.
It is faster than `apt-get`.
It shows more output in the terminal.

2. `rm` requires the use of `sudo` to work.

3. `sudo apt clean` and `sudo rm -rf /var/lib/apt/lists/*` are not required to uninstall Etcher.

4. Use `apt autoremove` to uninstall not required packages and have a cleaner uninstallation.