### PR TITLE
patch: Fix auto update

### DIFF
--- a/lib/gui/etcher.ts
+++ b/lib/gui/etcher.ts
@@ -43,7 +43,7 @@ async function checkForUpdates(interval: number) {
 				const release = await autoUpdater.checkForUpdates();
 				const isOutdated =
 					semver.compare(release.updateInfo.version, version) > 0;
-				const shouldUpdate = release.updateInfo.stagingPercentage !== 0; // undefinded means 100%
+				const shouldUpdate = release.updateInfo.stagingPercentage !== 0; // undefinded (default) means 100%
 				if (shouldUpdate && isOutdated) {
 					await autoUpdater.downloadUpdate();
 					packageUpdated = true;

--- a/lib/gui/etcher.ts
+++ b/lib/gui/etcher.ts
@@ -43,7 +43,7 @@ async function checkForUpdates(interval: number) {
 				const release = await autoUpdater.checkForUpdates();
 				const isOutdated =
 					semver.compare(release.updateInfo.version, version) > 0;
-				const shouldUpdate = release.updateInfo.stagingPercentage || 0 > 0;
+				const shouldUpdate = release.updateInfo.stagingPercentage !== 0; // undefinded means 100%
 				if (shouldUpdate && isOutdated) {
 					await autoUpdater.downloadUpdate();
 					packageUpdated = true;


### PR DESCRIPTION
When the `stagingPercentage` is not set in the `latest*.yml` it should mean 100%
The previous version expected that the property is always present with a value of `0` or `100` was not prepared for `undefined`