### PR TITLE
Fix application directory for Debian postinst script

### DIFF
--- a/after-install.tpl
+++ b/after-install.tpl
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Link to the binary
+# Must hardcode balenaEtcher directory; no variable available
+ln -sf '/opt/balenaEtcher/${executable}' '/usr/bin/${executable}'
+
+# SUID chrome-sandbox for Electron 5+
+chmod 4755 '/opt/balenaEtcher/chrome-sandbox' || true
+
+update-mime-database /usr/share/mime || true
+update-desktop-database /usr/share/applications || true

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -87,6 +87,7 @@ deb:
     - libxss1
     - libxtst6
     - polkit-1-auth-agent | policykit-1-gnome | polkit-kde-1
+  afterInstall: "./after-install.tpl"
 rpm:
   depends:
     - util-linux


### PR DESCRIPTION
Add an after-install template file to the configuration to fix the `postinst` script for the Debian package. See electron-builder [LinuxSpecificTargetOptions](https://www.electron.build/generated/linuxtargetspecificoptions). Must hardcode the application directory name in the script because there is not a variable available with the content of 'balenaEtcher', as you can see in the [app-builder-lib source](https://github.com/electron-userland/electron-builder/blob/24e986e664f89b8a41f4e5032709a73d30667f9d/packages/app-builder-lib/src/targets/fpm.ts#L37).

`productFilename`, the variable used historically for the app directory, uses `executableName` due to [this code](https://github.com/electron-userland/electron-builder/blob/24e986e664f89b8a41f4e5032709a73d30667f9d/packages/app-builder-lib/src/appInfo.ts#L66) in the appInfo module.

Fixes #3486