### PR TITLE
Remove Homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,22 +170,6 @@ yay -S balena-etcher
 yay -R balena-etcher
 ```
 
-#### Brew (macOS)
-
-**Note**: Etcher has to be updated manually to point to new versions,
-so it might not refer to the latest version immediately after an Etcher
-release.
-
-```sh
-brew install balenaetcher
-```
-
-##### Uninstall
-
-```sh
-brew uninstall balenaetcher
-```
-
 #### Chocolatey (Windows)
 
 This package is maintained by [@majkinetor](https://github.com/majkinetor), and


### PR DESCRIPTION
We have frozen etcher at `v1.8.14` and discontinued support for it in Homebrew.