### PR TITLE
Fixing call to electron block screensaver methods invocation

### DIFF
--- a/lib/gui/app/models/flash-state.ts
+++ b/lib/gui/app/models/flash-state.ts
@@ -47,7 +47,7 @@ export function isFlashing(): boolean {
  */
 export function setFlashingFlag() {
 	// see https://github.com/balenablocks/balena-electron-env/blob/4fce9c461f294d4a768db8f247eea6f75d7b08b0/README.md#remote-methods
-	electron.ipcRenderer.send('disable-screensaver');
+	electron.ipcRenderer.invoke('disable-screensaver');
 	store.dispatch({
 		type: Actions.SET_FLASHING_FLAG,
 		data: {},
@@ -70,7 +70,7 @@ export function unsetFlashingFlag(results: {
 		data: results,
 	});
 	// see https://github.com/balenablocks/balena-electron-env/blob/4fce9c461f294d4a768db8f247eea6f75d7b08b0/README.md#remote-methods
-	electron.ipcRenderer.send('enable-screensaver');
+	electron.ipcRenderer.invoke('enable-screensaver');
 }
 
 export function setDevicePaths(devicePaths: string[]) {


### PR DESCRIPTION
Replacing `send` calls to `invoke` for `enable/disable-screensaver` calls.

Change-type: patch
Connects-To: https://github.com/balena-io-hardware/EtcherPro-Fleet/issues/27
Signed-off-by: Aurelien VALADE <aurelien.valade@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Build output been rebuilt and tested (on linux aarch64 only)
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---