### PR TITLE
Patch: run linux build on ubuntu-18.04

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -20,5 +20,5 @@ jobs:
       (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
     with:
-      tests_run_on: '["ubuntu-latest","macos-latest","windows-2019"]'
+      tests_run_on: '["ubuntu-18.04","macos-latest","windows-2019"]'
       restrict_custom_actions: false


### PR DESCRIPTION
Running on ubuntu-latest means you need a more recent version of glibc which breaks on older ubuntu.

Thanks to @theofficialgman for suggesting the fix.