### PR TITLE
Dummy update to fix asset version issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,5 @@ the [license].
 [milestones]: https://github.com/balena-io/etcher/milestones
 [newissue]: https://github.com/balena-io/etcher/issues/new
 [license]: https://github.com/balena-io/etcher/blob/master/LICENSE
+
+


### PR DESCRIPTION
Due to a race between two patch, 1.10.5 assets are labelled 1.10.3. This dummy PR should fix this.

Change-type: patch