### PR TITLE
Patch: run linux build on ubuntu-20.04

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
     with:
-      tests_run_on: '["ubuntu-18.04","macos-latest","windows-2019"]'
+      tests_run_on: '["ubuntu-20.04","macos-latest","windows-2019"]'
       restrict_custom_actions: false
       github_prerelease: true
       repo_config: true


### PR DESCRIPTION
as [`18.04` has been removed](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

We cannot use `latest` as the glibc version will cause issue with older ubuntu version.