### PR TITLE
fix disabled-screensaver unhandled exception outside balena-electron env

### DIFF
--- a/lib/gui/app/models/flash-state.ts
+++ b/lib/gui/app/models/flash-state.ts
@@ -47,7 +47,13 @@ export function isFlashing(): boolean {
  */
 export function setFlashingFlag() {
 	// see https://github.com/balenablocks/balena-electron-env/blob/4fce9c461f294d4a768db8f247eea6f75d7b08b0/README.md#remote-methods
-	electron.ipcRenderer.invoke('disable-screensaver');
+	try {
+		electron.ipcRenderer.invoke('disable-screensaver');
+	} catch (error) {
+		console.log(
+			"Can't disable-screensaver, we're probably not running on a balena-electron env",
+		);
+	}
 	store.dispatch({
 		type: Actions.SET_FLASHING_FLAG,
 		data: {},

--- a/lib/gui/app/modules/analytics.ts
+++ b/lib/gui/app/modules/analytics.ts
@@ -221,9 +221,9 @@ export async function logEvent(message: string, data: AnalyticsPayload = {}) {
  */
 export function logException(error: any) {
 	const shouldReportErrors = settings.getSync('errorReporting');
+	console.error(error);
 	if (shouldReportErrors) {
 		initAnalytics();
-		console.error(error);
 		SentryRenderer.captureException(error);
 	}
 }

--- a/lib/gui/etcher.ts
+++ b/lib/gui/etcher.ts
@@ -65,8 +65,8 @@ async function checkForUpdates(interval: number) {
 
 function logMainProcessException(error: any) {
 	const shouldReportErrors = settings.getSync('errorReporting');
+	console.error(error);
 	if (shouldReportErrors) {
-		console.error(error);
 		SentryMain.captureException(error);
 	}
 }


### PR DESCRIPTION
Only makes sense on etcher-pro, polluting sentry with useless reports

Change-type: patch