### PR TITLE
Add support for Node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -236,9 +236,9 @@
       "dev": true
     },
     "@aws-crypto/ie11-detection": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.11.1"
@@ -253,16 +253,16 @@
       }
     },
     "@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "dev": true,
       "requires": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -277,13 +277,13 @@
       }
     },
     "@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "dev": true,
       "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -296,9 +296,9 @@
       }
     },
     "@aws-crypto/supports-web-crypto": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "dev": true,
       "requires": {
         "tslib": "^1.11.1"
@@ -313,12 +313,12 @@
       }
     },
     "@aws-crypto/util": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
@@ -332,833 +332,573 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.193.0.tgz",
-      "integrity": "sha512-MYPBm5PWyKP+Tq37mKs5wDbyAyVMocF5iYmx738LYXBSj8A1V4LTFrvfd4U16BRC/sM0DYB9fBFJUQ9ISFRVYw==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.257.0.tgz",
+      "integrity": "sha512-ekWy391lOerS0ZECdhp/c+X7AToJIpfNrCPjuj3bKr+GMQYckGsYsdbm6AUD4sxBmfvuaQmVniSXWovaxwcFcQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.196.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.196.0.tgz",
-      "integrity": "sha512-u+UnxrVHLjLDdfCZft1AuyIhyv+77/inCHR4LcKsGASRA+jAg3z+OY+B7Q9hWHNcVt5ECMw7rxe4jA9BLf42sw==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.259.0.tgz",
+      "integrity": "sha512-TKi9Lj0zqxsrQWOZ+e4WchNDtLDz6B+ahMzYDIOFlglDPPEzbZE//PBMZCba/AAIe6U3xaUQSnni+4mNbRLg7Q==",
       "dev": true,
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.193.0",
-        "@aws-sdk/fetch-http-handler": "3.193.0",
-        "@aws-sdk/hash-node": "3.193.0",
-        "@aws-sdk/invalid-dependency": "3.193.0",
-        "@aws-sdk/middleware-content-length": "3.193.0",
-        "@aws-sdk/middleware-endpoint": "3.193.0",
-        "@aws-sdk/middleware-host-header": "3.193.0",
-        "@aws-sdk/middleware-logger": "3.193.0",
-        "@aws-sdk/middleware-recursion-detection": "3.193.0",
-        "@aws-sdk/middleware-retry": "3.193.0",
-        "@aws-sdk/middleware-serde": "3.193.0",
-        "@aws-sdk/middleware-stack": "3.193.0",
-        "@aws-sdk/middleware-user-agent": "3.193.0",
-        "@aws-sdk/node-config-provider": "3.193.0",
-        "@aws-sdk/node-http-handler": "3.193.0",
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/smithy-client": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/url-parser": "3.193.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.193.0",
-        "@aws-sdk/util-defaults-mode-node": "3.193.0",
-        "@aws-sdk/util-endpoints": "3.196.0",
-        "@aws-sdk/util-user-agent-browser": "3.193.0",
-        "@aws-sdk/util-user-agent-node": "3.193.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.259.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.259.0.tgz",
+      "integrity": "sha512-TKpUX55qLM35sQXx96VnB/ZcQCcBxVU/0j0wqL8Hij+blD7fy6KrGGJPORzRphmFg8Ehf1IoCivFxrQwLrjZ6A==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.259.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.196.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.196.0.tgz",
-      "integrity": "sha512-ChzK8606CugwnRLm7iwerXzeMqOsjGLe3j1j1HtQShzXZu4/ysQ3mUBBPAt2Lltx+1ep8MoI9vaQVyfw5h35ww==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.259.0.tgz",
+      "integrity": "sha512-LXqua4FoXxR30sM4BSwmPI6x0YmDTw6yQhxQQXA5hrx+YwUf8CSpa0K6Xwfv8M5+zP0uHfY1iVxx/rnT8FOEmA==",
       "dev": true,
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.193.0",
-        "@aws-sdk/credential-provider-node": "3.196.0",
-        "@aws-sdk/fetch-http-handler": "3.193.0",
-        "@aws-sdk/hash-node": "3.193.0",
-        "@aws-sdk/invalid-dependency": "3.193.0",
-        "@aws-sdk/middleware-content-length": "3.193.0",
-        "@aws-sdk/middleware-endpoint": "3.193.0",
-        "@aws-sdk/middleware-host-header": "3.193.0",
-        "@aws-sdk/middleware-logger": "3.193.0",
-        "@aws-sdk/middleware-recursion-detection": "3.193.0",
-        "@aws-sdk/middleware-retry": "3.193.0",
-        "@aws-sdk/middleware-sdk-sts": "3.193.0",
-        "@aws-sdk/middleware-serde": "3.193.0",
-        "@aws-sdk/middleware-signing": "3.193.0",
-        "@aws-sdk/middleware-stack": "3.193.0",
-        "@aws-sdk/middleware-user-agent": "3.193.0",
-        "@aws-sdk/node-config-provider": "3.193.0",
-        "@aws-sdk/node-http-handler": "3.193.0",
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/smithy-client": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/url-parser": "3.193.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-node": "3.259.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-sdk-sts": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.193.0",
-        "@aws-sdk/util-defaults-mode-node": "3.193.0",
-        "@aws-sdk/util-endpoints": "3.196.0",
-        "@aws-sdk/util-user-agent-browser": "3.193.0",
-        "@aws-sdk/util-user-agent-node": "3.193.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.259.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.193.0.tgz",
-      "integrity": "sha512-HIjuv2A1glgkXy9g/A8bfsiz3jTFaRbwGZheoHFZod6iEQQEbbeAsBe3u2AZyzOrVLgs8lOvBtgU8XKSJWjDkw==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.259.0.tgz",
+      "integrity": "sha512-gViMRsc4Ye6+nzJ0OYTZIT8m4glIAdtugN2Sr/t6P2iJW5X0bSL/EcbcHBgsve1lHjeGPeyzVkT7UnyGOZ5Z/A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/signature-v4": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/util-config-provider": "3.188.0",
-        "@aws-sdk/util-middleware": "3.193.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.193.0.tgz",
-      "integrity": "sha512-pRqZoIaqCdWB4JJdR6DqDn3u+CwKJchwiCPnRtChwC8KXCMkT4njq9J1bWG3imYeTxP/G06O1PDONEuD4pPtNQ==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.257.0.tgz",
+      "integrity": "sha512-GsmBi5Di6hk1JAi1iB6/LCY8o+GmlCvJoB7wuoVmXI3VxRVwptUVjuj8EtJbIrVGrF9dSuIRPCzUoSuzEzYGlg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.193.0.tgz",
-      "integrity": "sha512-jC7uT7uVpO/iitz49toHMGFKXQ2igWQQG2SKirREqDRaz5HSXwEP1V3rcOlNNyGIBPMggDjZnxYgJHqBXSq9Ag==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.259.0.tgz",
+      "integrity": "sha512-yCxoYWZAaDrCUEWxRfrpB0Mp1cFgJEMYW8T6GIb/+DQ5QLpZmorgaVD/j90QXupqFrR5tlxwuskBIkdD2E9YNg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.193.0",
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/url-parser": "3.193.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.196.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.196.0.tgz",
-      "integrity": "sha512-3lL+YLBQ9KwQxG4AdRm4u2cvBNZeBmS/i3BWnCPomg96lNGPMrTEloVaVEpnrzOff6sgFxRtjkbLkVxmdipIrw==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.259.0.tgz",
+      "integrity": "sha512-/sjZv+XvcSMnvDTsau0cHxMFcbz4f4ksvgu10JQ1PpcH5CPQJviDJjZRzzijcOuMZ3SOO0skyuYU6tjY18cgIg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.193.0",
-        "@aws-sdk/credential-provider-imds": "3.193.0",
-        "@aws-sdk/credential-provider-sso": "3.196.0",
-        "@aws-sdk/credential-provider-web-identity": "3.193.0",
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/shared-ini-file-loader": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.259.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.196.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.196.0.tgz",
-      "integrity": "sha512-PGY7pkmqgfEwTHsuUH6fGrXWri93jqKkMbhq/QJafMGtsVupfvXvE37Rl+qgjsZjRfROrEaeLw2DGrPPmVh2cg==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.259.0.tgz",
+      "integrity": "sha512-7doM6hCPTZD0H+A7VtElLY4Ztuhg3MbjoHs00TyPZNCym7f/AKmKi9Exiw1tGgxTJkfn/SzcAWz+TyqMP078ow==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.193.0",
-        "@aws-sdk/credential-provider-imds": "3.193.0",
-        "@aws-sdk/credential-provider-ini": "3.196.0",
-        "@aws-sdk/credential-provider-process": "3.193.0",
-        "@aws-sdk/credential-provider-sso": "3.196.0",
-        "@aws-sdk/credential-provider-web-identity": "3.193.0",
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/shared-ini-file-loader": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-ini": "3.259.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.259.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.193.0.tgz",
-      "integrity": "sha512-zpXxtQzQqkaUuFqmHW9dSkh9p/1k+XNKlwEkG8FTwAJNUWmy2ZMJv+8NTVn4s4vaRu7xJ1er9chspYr7mvxHlA==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.257.0.tgz",
+      "integrity": "sha512-xK8uYeNXaclaBCGrLi4z2pxPRngqLf5BM5jg2fn57zqvlL9V5gJF972FehrVBL0bfp1/laG0ZJtD2K2sapyWAw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/shared-ini-file-loader": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.196.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.196.0.tgz",
-      "integrity": "sha512-hJV4LDVfvPfj5zC0ysHx3zkwwJOyF+BaMGaMzaScrHyijv5e3qZzdoBLbOQFmrqVnt7DjCU02NvRSS8amLpmSw==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.259.0.tgz",
+      "integrity": "sha512-cz+8aNKxvZ8ikd0JDcB9MZredOJNRZkbco8QAM0gXfy6ziyX+23oU8+aekZljDzQR5QNRouvMz1KKmBxZLpNyg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.196.0",
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/shared-ini-file-loader": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/client-sso": "3.259.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/token-providers": "3.259.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.193.0.tgz",
-      "integrity": "sha512-MIQY9KwLCBnRyIt7an4EtMrFQZz2HC1E8vQDdKVzmeQBBePhW61fnX9XDP9bfc3Ypg1NggLG00KBPEC88twLFg==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.257.0.tgz",
+      "integrity": "sha512-Cm0uvRv4JuIbD0Kp3W0J/vwjADIyCx8HoZi5yg+QIi5nilocuTQ3ajvLeuPVSvFvdy+yaxSc5FxNXquWt7Mngw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.193.0.tgz",
-      "integrity": "sha512-UhIS2LtCK9hqBzYVon6BI8WebJW1KC0GGIL/Gse5bqzU9iAGgFLAe66qg9k+/h3Jjc5LNAYzqXNVizMwn7689Q==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.257.0.tgz",
+      "integrity": "sha512-zOF+RzQ+wfF7tq7tGUdPcqUTh3+k2f8KCVJE07A8kCopVq4nBu4NH6Eq29Tjpwdya3YlKvE+kFssuQRRRRex+Q==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/querystring-builder": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/querystring-builder": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.193.0.tgz",
-      "integrity": "sha512-O2SLPVBjrCUo+4ouAdRUoHBYsyurO9LcjNZNYD7YQOotBTbVFA3cx7kTZu+K4B6kX7FDaGbqbE1C/T1/eg/r+w==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.257.0.tgz",
+      "integrity": "sha512-W/USUuea5Ep3OJ2U7Ve8/5KN1YsDun2WzOFUxc1PyxXP5pW6OgC15/op0e+bmWPG851clvp5S8ZuroUr3aKi3Q==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/util-buffer-from": "3.188.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.193.0.tgz",
-      "integrity": "sha512-54DCknekLwJAI1os76XJ8XCzfAH7BGkBGtlWk5WCNkZTfj3rf5RUiXz4uoKUMWE1rZmyMDoDDS1PBo+yTVKW5w==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.257.0.tgz",
+      "integrity": "sha512-T68SAPRNMEhpke0wlxURgogL7q0B8dfqZsSeS20BVR/lksJxLse9+pbmCDxiu1RrXoEIsEwl5rbLN+Hw8BFFYw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
-      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.193.0.tgz",
-      "integrity": "sha512-em0Sqo7O7DFOcVXU460pbcYuIjblDTZqK2YE62nQ0T+5Nbj+MSjuoite+rRRdRww9VqBkUROGKON45bUNjogtQ==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
+      "integrity": "sha512-yiawbV2azm6QnMY1L2ypG8PDRdjOcEIvFmT0T7y0F49rfbKJOu21j1ONAoCkLrINK6kMqcD5JSQLVCoURxiTxQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-endpoint": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.193.0.tgz",
-      "integrity": "sha512-Inbpt7jcHGvzF7UOJOCxx9wih0+eAQYERikokidWJa7M405EJpVYq1mGbeOcQUPANU3uWF1AObmUUFhbkriHQw==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.257.0.tgz",
+      "integrity": "sha512-RQNQe/jeVuWZtXXfcOm+e3qMFICY6ERsXUrbt0rjHgvajZCklcrRJgxJSCwrcS7Le3nl9azFPMAMj9L7uSK28g==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-serde": "3.193.0",
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/signature-v4": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/url-parser": "3.193.0",
-        "@aws-sdk/util-config-provider": "3.188.0",
-        "@aws-sdk/util-middleware": "3.193.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.193.0.tgz",
-      "integrity": "sha512-aegzj5oRWd//lmfmkzRmgG2b4l3140v8Ey4QkqCxcowvAEX5a7rh23yuKaGtmiePwv2RQalCKz+tN6JXCm8g6Q==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.257.0.tgz",
+      "integrity": "sha512-gEi9AJdJfRfU8Qr6HK1hfhxTzyV3Giq4B/h7um99hIFAT/GCg9xiPvAOKPo6UeuiKEv3b7RpSL4s6cBvnJMJBA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.193.0.tgz",
-      "integrity": "sha512-D/h1pU5tAcyJpJ8ZeD1Sta0S9QZPcxERYRBiJdEl8VUrYwfy3Cl1WJedVOmd5nG73ZLRSyHeXHewb/ohge3yKQ==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.257.0.tgz",
+      "integrity": "sha512-8RDXW/VbMKBsXDfcCLmROZcWKyrekyiPa3J1aIaBy0tq9o4xpGoXw/lwwIrNVvISAFslb57rteup34bfn6ta6w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.193.0.tgz",
-      "integrity": "sha512-fMWP76Q1GOb/9OzS1arizm6Dbfo02DPZ6xp7OoAN3PS6ybH3Eb47s/gP3jzgBPAITQacFj4St/4a06YWYrN3NA==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.257.0.tgz",
+      "integrity": "sha512-rUCih6zHh8k9Edf5N5Er4s508FYbwLM0MWTD2axzlj9TjLqEQ9OKED3wHaLffXSDzodd3oTAfJCLPbWQyoZ3ZQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.193.0.tgz",
-      "integrity": "sha512-zTQkHLBQBJi6ns655WYcYLyLPc1tgbEYU080Oc8zlveLUqoDn1ogkcmNhG7XMeQuBvWZBYN7J3/wFaXlDzeCKg==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.259.0.tgz",
+      "integrity": "sha512-pVh1g8e84MAi7eVtWLiiiCtn82LzxOP7+LxTRHatmgIeN22yGQBZILliPDJypUPvDYlwxI1ekiK+oPTcte0Uww==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/service-error-classification": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/util-middleware": "3.193.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/service-error-classification": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.193.0.tgz",
-      "integrity": "sha512-TafiDkeflUsnbNa89TLkDnAiRRp1gAaZLDAjt75AzriRKZnhtFfYUXWb+qAuN50T+CkJ/gZI9LHDZL5ogz/HxQ==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.257.0.tgz",
+      "integrity": "sha512-d6IJCLRi3O2tm4AFK60WNhIwmMmspj1WzKR1q1TaoPzoREPG2xg+Am18wZBRkCyYuRPPrbizmkvAmAJiUolMAw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.193.0",
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/signature-v4": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.193.0.tgz",
-      "integrity": "sha512-dH93EJYVztY+ZDPzSMRi9LfAZfKO+luH62raNy49hlNa4jiyE1Tc/+qwlmOEpfGsrtcZ9TgsON1uFF9sgBXXaA==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.257.0.tgz",
+      "integrity": "sha512-/JasfXPWFq24mnCrx9fxW/ISBSp07RJwhsF14qzm8Qy3Z0z470C+QRM6otTwAkYuuVt1wuLjja5agq3Jtzq7dQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.193.0.tgz",
-      "integrity": "sha512-obBoELGPf5ikvHYZwbzllLeuODiokdDfe92Ve2ufeOa/d8+xsmbqNzNdCTLNNTmr1tEIaEE7ngZVTOiHqAVhyw==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.257.0.tgz",
+      "integrity": "sha512-hCH3D83LHmm6nqmtNrGTWZCVjsQXrGHIXbd17/qrw7aPFvcAhsiiCncGFP+XsUXEKa2ZqcSNMUyPrx69ofNRZQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/signature-v4": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/util-middleware": "3.193.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-middleware": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.193.0.tgz",
-      "integrity": "sha512-Ix5d7gE6bZwFNIVf0dGnjYuymz1gjitNoAZDPpv1nEZlUMek/jcno5lmzWFzUZXY/azpbIyaPwq/wm/c69au5A==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.257.0.tgz",
+      "integrity": "sha512-awg2F0SvwACBaw4HIObK8pQGfSqAc4Vy+YFzWSfZNVC35oRO6RsRdKHVU99lRC0LrT2Ptmfghl2DMPSrRDbvlQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.193.0.tgz",
-      "integrity": "sha512-0vT6F9NwYQK7ARUUJeHTUIUPnupsO3IbmjHSi1+clkssFlJm2UfmSGeafiWe4AYH3anATTvZEtcxX5DZT/ExbA==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.257.0.tgz",
+      "integrity": "sha512-37rt75LZyD0UWpbcFuxEGqwF3DZKSixQPl7AsDe6q3KtrO5gGQB+diH5vbY0txNNYyv5IK9WMwvY73mVmoWRmw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.193.0.tgz",
-      "integrity": "sha512-5RLdjQLH69ISRG8TX9klSLOpEySXxj+z9E9Em39HRvw0/rDcd8poCTADvjYIOqRVvMka0z/hm+elvUTIVn/DRw==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.259.0.tgz",
+      "integrity": "sha512-DUOqr71oonBvM6yKPdhDBmraqgXHCFrVWFw7hc5ZNxL2wS/EsbKfGPJp+C+SUgpn1upIWPNnh/bNoLAbBkcLsA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/shared-ini-file-loader": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.193.0.tgz",
-      "integrity": "sha512-DP4BmFw64HOShgpAPEEMZedVnRmKKjHOwMEoXcnNlAkMXnYUFHiKvudYq87Q2AnSlT6OHkyMviB61gEvIk73dA==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.257.0.tgz",
+      "integrity": "sha512-8KnWHVVwaGKyTlkTU9BSOAiSovNDoagxemU2l10QqBbzUCVpljCUMUkABEGRJ1yoQCl6DJ7RtNkAyZ8Ne/E15A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/abort-controller": "3.193.0",
-        "@aws-sdk/protocol-http": "3.193.0",
-        "@aws-sdk/querystring-builder": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/abort-controller": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/querystring-builder": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.193.0.tgz",
-      "integrity": "sha512-IaDR/PdZjKlAeSq2E/6u6nkPsZF9wvhHZckwH7uumq4ocWsWXFzaT+hKpV4YZPHx9n+K2YV4Gn/bDedpz99W1Q==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.257.0.tgz",
+      "integrity": "sha512-3rUbRAcF0GZ5PhDiXhS4yREfZ5hOEtvYEa9S/19OdM5eoypOaLU5XnFcCKfnccSP8SkdgpJujzxOMRWNWadlAQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.193.0.tgz",
-      "integrity": "sha512-r0wbTwFJyXq0uiImI6giqG3g/RO1N/y4wwPA7qr7OC+KXJ0NkyVxIf6e7Vx8h06aM1ATtngbwJaMP59kVCp85A==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.257.0.tgz",
+      "integrity": "sha512-xt7LGOgZIvbLS3418AYQLacOqx+mo5j4mPiIMz7f6AaUg+/fBUgESVsncKDqxbEJVwwCXSka8Ca0cntJmoeMSw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.193.0.tgz",
-      "integrity": "sha512-PRaK6649iw0UO45UjUoiUzFcOKXZb8pMjjFJpqALpEvdZT3twxqhlPXujT7GWPKrSwO4uPLNnyYEtPY82wx2vw==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.257.0.tgz",
+      "integrity": "sha512-mZHWLP7XIkzx1GIXO5WfX/iJ+aY9TWs02RE9FkdL2+by0HEMR65L3brQTbU1mIBJ7BjaPwYH24dljUOSABX7yg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.193.0.tgz",
-      "integrity": "sha512-dGEPCe8SK4/td5dSpiaEI3SvT5eHXrbJWbLGyD4FL3n7WCGMy2xVWAB/yrgzD0GdLDjDa8L5vLVz6yT1P9i+hA==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.257.0.tgz",
+      "integrity": "sha512-UDrE1dEwWrWT8dG2VCrGYrPxCWOkZ1fPTPkjpkR4KZEdQDZBqU5gYZF2xPj8Nz7pjQVHFuW2wFm3XYEk56GEjg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.193.0.tgz",
-      "integrity": "sha512-bPnXVu8ErE1RfWVVQKc2TE7EuoImUi4dSPW9g80fGRzJdQNwXb636C+7OUuWvSDzmFwuBYqZza8GZjVd+rz2zQ==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.257.0.tgz",
+      "integrity": "sha512-FAyR0XsueGkkqDtkP03cTJQk52NdQ9sZelLynmmlGPUP75LApRPvFe1riKrou6+LsDbwVNVffj6mbDfIcOhaOw==",
       "dev": true
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.193.0.tgz",
-      "integrity": "sha512-hnvZup8RSpFXfah7Rrn6+lQJnAOCO+OiDJ2R/iMgZQh475GRQpLbu3cPhCOkjB14vVLygJtW8trK/0+zKq93bQ==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.257.0.tgz",
+      "integrity": "sha512-HNjC1+Wx3xHiJc+CP14GhIdVhfQGSjroAsWseRxAhONocA9Fl1ZX4hx7+sA5c9nOoMVOovi6ivJ/6lCRPTDRrQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.193.0.tgz",
-      "integrity": "sha512-JEqqOB8wQZz6g1ERNUOIBFDFt8OJtz5G5Uh1CdkS5W66gyWnJEz/dE1hA2VTqqQwHGGEsIEV/hlzruU1lXsvFA==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.257.0.tgz",
+      "integrity": "sha512-aLQQN59X/D0+ShzPD3Anj5ntdMA/RFeNLOUCDyDvremViGi6yxUS98usQ/8bG5Rq0sW2GGMdbFUFmrDvqdiqEQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
-        "@aws-sdk/types": "3.193.0",
-        "@aws-sdk/util-hex-encoding": "3.188.0",
-        "@aws-sdk/util-middleware": "3.193.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.193.0.tgz",
-      "integrity": "sha512-BY0jhfW76vyXr7ODMaKO3eyS98RSrZgOMl6DTQV9sk7eFP/MPVlG7p7nfX/CDIgPBIO1z0A0i2CVIzYur9uGgQ==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.257.0.tgz",
+      "integrity": "sha512-Vy/en+llpslHG6WZ2yuN+On6u7p2hROEURwAST/lpReAwBETjbsxylkWvP8maeGKQ54u9uC6lIZAOJut2I3INw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-stack": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.259.0.tgz",
+      "integrity": "sha512-61lbk+vjlHBtNK7ZOTdR0rgk9dQ6++tklHpXZY3AQWAl3xx6K4y00HsyAtcP6k24s8B356QwXlrQJrQY5nnkQQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.259.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.193.0.tgz",
-      "integrity": "sha512-LV/wcPolRZKORrcHwkH59QMCkiDR5sM+9ZtuTxvyUGG2QFW/kjoxs08fUF10OWNJMrotBI+czDc5QJRgN8BlAw==",
-      "dev": true
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.257.0.tgz",
+      "integrity": "sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "@aws-sdk/url-parser": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.193.0.tgz",
-      "integrity": "sha512-hwD1koJlOu2a6GvaSbNbdo7I6a3tmrsNTZr8bCjAcbqpc5pDThcpnl/Uaz3zHmMPs92U8I6BvWoK6pH8By06qw==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.257.0.tgz",
+      "integrity": "sha512-Qe/AcFe/NFZHa6cN2afXEQn9ehXxh57dWGdRjfjd2lQqNV4WW1R2pl2Tm1ZJ1dwuCNLJi4NHLMk8lrD3QQ8rdg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/querystring-parser": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/querystring-parser": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
-    "@aws-sdk/util-base64-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
-      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
       "dev": true,
       "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
-      }
-    },
-    "@aws-sdk/util-base64-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
-      "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-body-length-browser": {
@@ -1168,267 +908,157 @@
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
-      "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
-      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
-      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.193.0.tgz",
-      "integrity": "sha512-9riQKFrSJcsNAMnPA/3ltpSxNykeO20klE/UKjxEoD7UWjxLwsPK22UJjFwMRaHoAFcZD0LU/SgPxbC0ktCYCg==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.257.0.tgz",
+      "integrity": "sha512-nkfK+MNacVd3Px/fcAvU0hDeh+r7d+RLLt3sJ5Zc0gGd+i3OQEP58V8QzR9PYMvUvSvGQP16fQVQHSbRZtuWyQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.193.0.tgz",
-      "integrity": "sha512-occQmckvPRiM4YQIZnulfKKKjykGKWloa5ByGC5gOEGlyeP9zJpfs4zc/M2kArTAt+d2r3wkBtsKe5yKSlVEhA==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.259.0.tgz",
+      "integrity": "sha512-wRiiwT7ayIcTYGHUg/Ho9UN/Kd4V37OAxP2IbkG9rPZJNuvtKopQJhUSMDERXaMQ47dG5US8G4YVYJIEO4cKgw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.193.0",
-        "@aws-sdk/credential-provider-imds": "3.193.0",
-        "@aws-sdk/node-config-provider": "3.193.0",
-        "@aws-sdk/property-provider": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.196.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.196.0.tgz",
-      "integrity": "sha512-X+DOpRUy/ij49a0GQtggk09oyIQGn0mhER6PbMT69IufZPIg3D5fC5FPEp8bfsPkb70fTEYQEsj/X/rgMQJKsA==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.257.0.tgz",
+      "integrity": "sha512-3bvmRn5XGYzPPWjLuvHBKdJOb+fijnb8Ungu9bfXnTYFsng/ndHUWeHC22O/p8w3OWoRYUIMaZHxdxe27BFozg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
-      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
-      "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.193.0.tgz",
-      "integrity": "sha512-+aC6pmkcGgpxaMWCH/FXTsGWl2W342oQGs1OYKGi+W8z9UguXrqamWjdkdMqgunvj9qOEG2KBMKz1FWFFZlUyA==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.257.0.tgz",
+      "integrity": "sha512-F9ieon8B8eGVs5tyZtAIG3DZEObDvujkspho0qRbUTHUosM0ylJLsMU800fmC/uRHLRrZvb/RSp59+kNDwSAMw==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.257.0.tgz",
+      "integrity": "sha512-l9TOsOAYtZxwW3q5fQKW4rsD9t2HVaBfQ4zBamHkNTfB4vBVvCnz4oxkvSvA2MlxCA6am+K1K/oj917Tpqk53g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.257.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
-      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.193.0.tgz",
-      "integrity": "sha512-1EkGYsUtOMEyJG/UBIR4PtmO3lVjKNoUImoMpLtEucoGbWz5RG9zFSwLevjFyFs5roUBFlxkSpTMo8xQ3aRzQg==",
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.257.0.tgz",
+      "integrity": "sha512-YdavWK6/8Cw6mypEgysGGX/dT9p9qnzFbnN5PQsUY+JJk2Nx8fKFydjGiQ+6rWPeW17RAv9mmbboh9uPVWxVlw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/types": "3.257.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.193.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.193.0.tgz",
-      "integrity": "sha512-G/2/1cSgsxVtREAm8Eq8Duib5PXzXknFRHuDpAxJ5++lsJMXoYMReS278KgV54cojOkAVfcODDTqmY3Av0WHhQ==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.259.0.tgz",
+      "integrity": "sha512-R0VTmNs+ySDDebU98BUbsLyeIM5YmAEr9esPpy15XfSy3AWmAeru8nLlztdaLilHZzLIDzvM2t7NGk/FzZFCvA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.193.0",
-        "@aws-sdk/types": "3.193.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/types": "3.257.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
-      "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@babel/code-frame": {
@@ -2689,9 +2319,9 @@
       }
     },
     "@balena/node-beaglebone-usbboot": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@balena/node-beaglebone-usbboot/-/node-beaglebone-usbboot-2.0.1.tgz",
-      "integrity": "sha512-OQfaLbSMAPEmh9UVTfXCVAjsPhqngfV87D0x+GGYdagwEggNOP3XwYxI5T53gu/tPZgjGmSeYiN8xxHG9JzSHA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/node-beaglebone-usbboot/-/node-beaglebone-usbboot-3.0.2.tgz",
+      "integrity": "sha512-S8zcVwGr8MY41GBR4A2gVbsj5GLWdbMKJReTd6Zf03m8De/sQJDm8VSHkT0WiaUiW/sAhl7ny+9h3E+f+k1OGw==",
       "dev": true,
       "requires": {
         "binary-parser-encoder": "^1.4.5",
@@ -2702,9 +2332,9 @@
       }
     },
     "@balena/node-crc-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@balena/node-crc-utils/-/node-crc-utils-2.0.1.tgz",
-      "integrity": "sha512-l+PZFPnO0vdx1HNaYq2p89mXIW8XcLoL7XjhwXAAbJ2FOmTg+8fgUEpohX+SJMxTUAE52FBTS8GzIKErCmBNTw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/node-crc-utils/-/node-crc-utils-3.0.0.tgz",
+      "integrity": "sha512-Gczabj4pMZ/ZstbgmdP8FcUoIYD3K/59TlTOPF3O2gfFyruRLR55620ESpJiF4Et93PeXy4yoJNFh7c35Y8xig==",
       "dev": true
     },
     "@balena/sudo-prompt": {
@@ -3116,30 +2746,19 @@
       }
     },
     "@npmcli/fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
       "dev": true,
       "requires": {
-        "@gar/promisify": "^1.1.3",
+        "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@npmcli/move-file": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
       "dev": true,
       "requires": {
         "mkdirp": "^1.0.4",
@@ -4631,6 +4250,15 @@
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
       "dev": true
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      }
+    },
     "agentkeepalive": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
@@ -4867,9 +4495,9 @@
       }
     },
     "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true
     },
     "archiver": {
@@ -4919,13 +4547,26 @@
       }
     },
     "are-we-there-yet": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
       "dev": true,
       "requires": {
         "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "arg": {
@@ -5044,9 +4685,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
     },
     "aws4-axios": {
@@ -5149,12 +4790,12 @@
       "dev": true
     },
     "balena-image-fs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/balena-image-fs/-/balena-image-fs-7.1.2.tgz",
-      "integrity": "sha512-f/RDGO/l4UdfHKoJb0BkBu9uPBG2OBuv7iK5z37ygIyBpFNCO+JdQcHjI4pM0kq6qHe98a/jNdBDMajJBhxMvQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/balena-image-fs/-/balena-image-fs-7.2.0.tgz",
+      "integrity": "sha512-CRY0NEvpaueMK2dlRG5WJJxyTRMmCdPlg92kOru2nCNhOLg1pQ1LXSrcRVPcserUVGx7HRRwXSCoZ7XcehW9QQ==",
       "dev": true,
       "requires": {
-        "ext2fs": "4.1.7",
+        "ext2fs": "^4.2.1",
         "fatfs": "^0.10.8",
         "file-disk": "^8.0.1",
         "partitioninfo": "^6.0.3",
@@ -5603,73 +5244,36 @@
       "dev": true
     },
     "cacache": {
-      "version": "16.1.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
       "dev": true,
       "requires": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
         "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
         "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
         "p-map": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
       },
       "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "chownr": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
           "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
           "dev": true
-        },
-        "glob": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "lru-cache": {
-          "version": "7.14.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
         },
         "mkdirp": {
           "version": "1.0.4",
@@ -7127,9 +6731,9 @@
       }
     },
     "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -7477,25 +7081,22 @@
       "dev": true
     },
     "drivelist": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-9.2.4.tgz",
-      "integrity": "sha512-F36yn+qXwiOGZM16FYPKcIRjC7qXDIA0SBZ0vvTEe01ai788Se8z78acYdgXC8NAsghiO+9c/GYXgU7E9hhUpg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-11.1.0.tgz",
+      "integrity": "sha512-DT328SbKqB78y+HUeuazwj4+Enh5ormv9OgTIMB0/OP2VxKLFDOrKhejJxjP9ytmJok8W/nzR8gSWdpiaJi1XA==",
       "dev": true,
       "requires": {
-        "bindings": "^1.3.0",
-        "debug": "^3.1.0",
-        "nan": "^2.14.0",
-        "prebuild-install": "^5.2.4"
+        "bindings": "^1.5.0",
+        "debug": "^4.3.4",
+        "node-addon-api": "^5.0.0",
+        "prebuild-install": "^7.1.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
+        "node-addon-api": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+          "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+          "dev": true
         }
       }
     },
@@ -8185,23 +7786,22 @@
       }
     },
     "electron-rebuild": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.9.tgz",
-      "integrity": "sha512-FkEZNFViUem3P0RLYbZkUjC8LUFIK+wKq09GHoOITSJjfDAVQv964hwaNseTTWt58sITQX3/5fHNYcTefqaCWw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.3.tgz",
+      "integrity": "sha512-9oxNmKlDCaf651c+yJWCDIBpF6A9aY+wQtasLEeR5AsPYPuOKEX6xHnC2+WgCLOC94JEpCZznecyC84fbwZq4A==",
       "dev": true,
       "requires": {
         "@malept/cross-spawn-promise": "^2.0.0",
-        "chalk": "^4.0.0",
+        "colors": "^1.3.3",
         "debug": "^4.1.1",
-        "detect-libc": "^2.0.1",
+        "detect-libc": "^1.0.3",
         "fs-extra": "^10.0.0",
         "got": "^11.7.0",
-        "lzma-native": "^8.0.5",
-        "node-abi": "^3.0.0",
+        "lzma-native": "^8.0.1",
+        "node-abi": "^2.19.2",
         "node-api-version": "^0.1.4",
-        "node-gyp": "^9.0.0",
+        "node-gyp": "^8.1.0",
         "ora": "^5.1.0",
-        "semver": "^7.3.5",
         "tar": "^6.0.5",
         "yargs": "^17.0.1"
       },
@@ -8230,15 +7830,6 @@
             "defer-to-connect": "^2.0.0"
           }
         },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "cacheable-request": {
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
@@ -8254,16 +7845,6 @@
             "responselike": "^2.0.0"
           }
         },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cliui": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -8275,19 +7856,10 @@
             "wrap-ansi": "^7.0.0"
           }
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
           "dev": true
         },
         "decompress-response": {
@@ -8303,12 +7875,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
           "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-          "dev": true
-        },
-        "detect-libc": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-          "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
           "dev": true
         },
         "fs-extra": {
@@ -8332,9 +7898,9 @@
           }
         },
         "got": {
-          "version": "11.8.5",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
-          "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+          "version": "11.8.6",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+          "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
           "dev": true,
           "requires": {
             "@sindresorhus/is": "^4.0.0",
@@ -8349,12 +7915,6 @@
             "p-cancelable": "^2.0.0",
             "responselike": "^2.0.0"
           }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
         },
         "json-buffer": {
           "version": "3.0.1",
@@ -8393,15 +7953,6 @@
           "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
           "dev": true
         },
-        "node-abi": {
-          "version": "3.28.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
-          "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
-          "dev": true,
-          "requires": {
-            "semver": "^7.3.5"
-          }
-        },
         "normalize-url": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -8421,24 +7972,6 @@
           "dev": true,
           "requires": {
             "lowercase-keys": "^2.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         },
         "universalify": {
@@ -8982,25 +8515,25 @@
       "dev": true
     },
     "etcher-sdk": {
-      "version": "7.4.8",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-7.4.8.tgz",
-      "integrity": "sha512-RADYlZCLFH7jmU4Nra9jehLhFm/CRjn2UYxZlzPCbjBrRqG83e+KDXMygN0VoNG8V22StqDpKlrMLRdd34OgYg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.2.0.tgz",
+      "integrity": "sha512-0YBgyqgsKtij7NG1+QzxUKxx6dWbzjSsQze2TXk4jTGs++AeD5c7rjG2GFEszF5xbMiePeQtAGt9GCb4UZRZiA==",
       "dev": true,
       "requires": {
-        "@balena/node-beaglebone-usbboot": "^2.0.1",
+        "@balena/node-beaglebone-usbboot": "^3.0.0",
         "@balena/udif": "^1.1.2",
         "@ronomon/direct-io": "^3.0.1",
         "aws4-axios": "^2.4.9",
         "axios": "^0.27.0",
-        "balena-image-fs": "^7.0.6",
+        "balena-image-fs": "^7.2.0",
         "blockmap": "^4.0.3",
         "check-disk-space": "^2.1.0",
         "cyclic-32": "^1.1.0",
         "debug": "^3.1.0",
-        "drivelist": "^9.2.4",
+        "drivelist": "^11.1.0",
         "file-disk": "^8.0.1",
         "file-type": "^16.5.4",
-        "gzip-stream": "^1.1.2",
+        "gzip-stream": "^2.0.0",
         "lzma-native": "^8.0.6",
         "mountutils": "^1.3.20",
         "node-raspberrypi-usbboot": "1.0.6",
@@ -9010,10 +8543,10 @@
         "tslib": "^2.0.0",
         "unbzip2-stream": "github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7",
         "unzip-stream": "^0.3.0",
-        "winusb-driver-generator": "1.2.7",
+        "winusb-driver-generator": "^1.5.0",
         "xxhash-addon": "^1.4.0",
         "yauzl": "^2.9.2",
-        "zip-part-stream": "^1.0.3"
+        "zip-part-stream": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -9177,9 +8710,9 @@
       }
     },
     "ext2fs": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/ext2fs/-/ext2fs-4.1.7.tgz",
-      "integrity": "sha512-saAfJb2G02DtCTiAWgtYcc9+D85z1vlEFLvuDolpBOJaK+X1Rr8VvvtBbhr4Vai3bdfIjpiBVl5BIKSdaL8ihA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ext2fs/-/ext2fs-4.2.1.tgz",
+      "integrity": "sha512-BEKVAC3FrhU39uWELK1DkjiMflx0efeFO8boFodwx18VkKCsGPrAU7NznwfXUl6mFIKlJ6Iu5FZxN6aJSmLlnw==",
       "dev": true
     },
     "extend": {
@@ -9552,54 +9085,28 @@
       "dev": true
     },
     "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
       "dev": true,
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+        "wide-align": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+          "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
+            "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         }
       }
@@ -9867,12 +9374,12 @@
       "dev": true
     },
     "gzip-stream": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/gzip-stream/-/gzip-stream-1.1.2.tgz",
-      "integrity": "sha512-r1nVZJGbHivD0RxzP+aGV4fs08dzh/IN5MCSR0bCa4FEPo7+azLiypR93f47NqzLZt7MSGf2f8vQ1PbfT3oNIg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-stream/-/gzip-stream-2.0.0.tgz",
+      "integrity": "sha512-Vf5SFUMy6NMJ0zyBHSdBnN8XfNvNBfW+0mnNdsnB65KhCxDY7G8BTTdKqgxuET/bxzHPa0us25I2z6Lqw/YsTg==",
       "dev": true,
       "requires": {
-        "@balena/node-crc-utils": "^2.0.0",
+        "@balena/node-crc-utils": "^3.0.0",
         "combined-stream": "^1.0.8",
         "crc32-stream": "^4.0.0"
       }
@@ -10178,6 +9685,16 @@
       "requires": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "human-signals": {
@@ -11529,53 +11046,45 @@
       "dev": true
     },
     "make-fetch-happen": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
       "dev": true,
       "requires": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
         "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
+        "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
         "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
+        "minipass-fetch": "^1.3.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
+        "negotiator": "^0.6.2",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "dev": true,
-          "requires": {
-            "debug": "4"
-          }
+        "@tootallnate/once": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+          "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+          "dev": true
         },
-        "https-proxy-agent": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+        "http-proxy-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
           "dev": true,
           "requires": {
+            "@tootallnate/once": "1",
             "agent-base": "6",
             "debug": "4"
           }
-        },
-        "lru-cache": {
-          "version": "7.14.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
-          "dev": true
         }
       }
     },
@@ -12121,15 +11630,15 @@
       }
     },
     "minipass-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
       "dev": true,
       "requires": {
-        "encoding": "^0.1.13",
-        "minipass": "^3.1.6",
+        "encoding": "^0.1.12",
+        "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
+        "minizlib": "^2.0.0"
       }
     },
     "minipass-flush": {
@@ -12435,6 +11944,28 @@
         "prebuild-install": "^4.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+          "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+          "dev": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
         "bl": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -12451,11 +11982,48 @@
           "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
           "dev": true
         },
+        "gauge": {
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+          "dev": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
         "minimist": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
           "dev": true
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
         },
         "prebuild-install": {
           "version": "4.0.0",
@@ -12499,6 +12067,26 @@
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
             "simple-concat": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
           }
         },
         "tar-fs": {
@@ -12682,17 +12270,6 @@
       "dev": true,
       "requires": {
         "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "node-fetch": {
@@ -12720,96 +12297,27 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.0.tgz",
-      "integrity": "sha512-A6rJWfXFz7TQNjpldJ915WFb1LnhO4lIve3ANPbWreuEoLoKlFT3sxIepPBkLhM27crW8YmN+pjlgbasH6cH/Q==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.0.3",
-        "nopt": "^6.0.0",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
         "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "tar": "^6.1.2",
         "which": "^2.0.2"
-      },
-      "dependencies": {
-        "are-we-there-yet": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-          "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-          "dev": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^3.6.0"
-          }
-        },
-        "gauge": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-          "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-          "dev": true,
-          "requires": {
-            "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.3",
-            "console-control-strings": "^1.1.0",
-            "has-unicode": "^2.0.1",
-            "signal-exit": "^3.0.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "wide-align": "^1.1.5"
-          }
-        },
-        "npmlog": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-          "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "^3.0.0",
-            "console-control-strings": "^1.1.0",
-            "gauge": "^4.0.3",
-            "set-blocking": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-          "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2 || 3 || 4"
-          }
-        }
       }
     },
     "node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "dev": true
     },
     "node-ipc": {
@@ -12846,12 +12354,12 @@
       "dev": true
     },
     "nopt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "dev": true,
       "requires": {
-        "abbrev": "^1.0.0"
+        "abbrev": "1"
       }
     },
     "normalize-path": {
@@ -12887,15 +12395,15 @@
       }
     },
     "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
       }
     },
     "nth-check": {
@@ -13425,33 +12933,45 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
-      "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
       "dev": true,
       "requires": {
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.7.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
+        "node-abi": "^3.3.0",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
+        "simple-get": "^4.0.0",
         "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "tunnel-agent": "^0.6.0"
       },
       "dependencies": {
+        "detect-libc": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+          "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+          "dev": true
+        },
         "minimist": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
           "dev": true
+        },
+        "node-abi": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.31.0.tgz",
+          "integrity": "sha512-eSKV6s+APenqVh8ubJyiu/YhZgxQpGP66ntzUb3lY1xB9ukSRaGnx0AIxI+IM+1+IVYC1oWobgG5L3Lt9ARykQ==",
+          "dev": true,
+          "requires": {
+            "semver": "^7.3.5"
+          }
         }
       }
     },
@@ -15077,29 +14597,29 @@
       "dev": true
     },
     "simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "dev": true,
       "requires": {
-        "decompress-response": "^4.2.0",
+        "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       },
       "dependencies": {
         "decompress-response": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
           "dev": true,
           "requires": {
-            "mimic-response": "^2.0.0"
+            "mimic-response": "^3.1.0"
           }
         },
         "mimic-response": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
           "dev": true
         }
       }
@@ -15365,34 +14885,14 @@
       }
     },
     "socks-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
       "dev": true,
       "requires": {
         "agent-base": "^6.0.2",
         "debug": "^4.3.3",
         "socks": "^2.6.2"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "dev": true,
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "source-list-map": {
@@ -15636,9 +15136,9 @@
       "dev": true
     },
     "ssri": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "dev": true,
       "requires": {
         "minipass": "^3.1.1"
@@ -16511,18 +16011,18 @@
       }
     },
     "unique-filename": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
-        "unique-slug": "^3.0.0"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
@@ -16649,9 +16149,9 @@
       }
     },
     "usb": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-2.6.0.tgz",
-      "integrity": "sha512-2FnACx4gy5K8R7nemeKr5UPe1veg/zq0v/ZD/3F+lVdLkpC84+cmy0xWvndh5mgvYYnOh11FkT46knRlSWFffw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.7.0.tgz",
+      "integrity": "sha512-63sB4hPrueUojpeNc8FpXkwO7CL36WbLSnrbK9S4QtS2+2FvZs3Ju8PGWRy2e7DaHLxYekFOJZMyZQ3ZmSu7Ag==",
       "dev": true,
       "requires": {
         "@types/w3c-web-usb": "^1.0.6",
@@ -17398,15 +16898,15 @@
       "dev": true
     },
     "winusb-driver-generator": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/winusb-driver-generator/-/winusb-driver-generator-1.2.7.tgz",
-      "integrity": "sha512-NMRpH61jvvU32kGp7TcB0uzC2vxbTNpdX8kkGn4RLafycm5bKRKNzIqinnshs8G5Z7VFAMVACaCo1uPLslT3nw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/winusb-driver-generator/-/winusb-driver-generator-1.5.0.tgz",
+      "integrity": "sha512-Wa809YPaQ1bUpOwb9zfkMKViyPP1F34NcLopoEX3l4UevS+XzsmHk6L9Hap1jgCUwWdpZ52yS1RMObllpF3zvA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "bindings": "^1.3.0",
-        "nan": "^2.14.0",
-        "prebuild-install": "^5.2.2"
+        "bindings": "^1.5.0",
+        "nan": "^2.17.0",
+        "prebuild-install": "^7.1.1"
       }
     },
     "wordwrap": {
@@ -17595,12 +17095,12 @@
       "dev": true
     },
     "zip-part-stream": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/zip-part-stream/-/zip-part-stream-1.0.3.tgz",
-      "integrity": "sha512-JJm6HvhvUCk7CHusOgRMvqYtMDVGj6HOQdTGxEs+ckWPysGScdZW3Y95pNZFeLZEgqbSTiDmaurLIH8osqdZiQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/zip-part-stream/-/zip-part-stream-2.0.0.tgz",
+      "integrity": "sha512-d2ZgYcCHH7q5aaZ6m/UKJQWsUT6FY7+IuOv0eIuVRUdyh5i6bxTo+aLB4dhGpdYsYx475XBsUvyOO4dBbqZGNw==",
       "dev": true,
       "requires": {
-        "@balena/node-crc-utils": "^2.0.0",
+        "@balena/node-crc-utils": "^3.0.0",
         "combined-stream": "^1.0.8",
         "crc32-stream": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "npm run lint-css"
     ]
   },
-  "author": "Balena Inc. <hello@etcher.io>",
+  "author": "Balena Ltd. <hello@balena.io>",
   "license": "Apache-2.0",
   "devDependencies": {
     "@balena/lint": "5.4.2",
@@ -70,20 +70,20 @@
     "@types/tmp": "0.2.3",
     "@types/webpack-node-externals": "2.5.3",
     "analytics-client": "^2.0.1",
-    "aws4-axios": "2.4.9",
+    "axios": "^0.27.2",
     "chai": "4.3.7",
     "copy-webpack-plugin": "7.0.0",
     "css-loader": "5.2.7",
     "d3": "4.13.0",
     "debug": "4.3.4",
-    "electron": "^13.5.0",
-    "electron-builder": "^23.0.9",
+    "electron": "^13.6.9",
+    "electron-builder": "^23.6.0",
     "electron-mocha": "9.3.3",
     "electron-notarize": "1.2.2",
-    "electron-rebuild": "3.2.9",
+    "electron-rebuild": "3.2.3",
     "electron-updater": "5.3.0",
     "esbuild-loader": "2.20.0",
-    "etcher-sdk": "^7.4.8",
+    "etcher-sdk": "^8.2.0",
     "file-loader": "6.2.0",
     "husky": "4.3.8",
     "i18next": "21.10.0",
@@ -124,7 +124,7 @@
     "webpack-dev-server": "4.11.1"
   },
   "engines": {
-    "node": ">=14 < 16"
+    "node": ">=14"
   },
   "versionist": {
     "publishedAt": "2023-01-19T12:21:03.371Z"


### PR DESCRIPTION
The Electron version we’re currently using is on Node 14 but this is a step forward to upgrading to a newer Electron and Node version.

Updates etcher-sdk and switches the redundant aws4-axios dependency to just axios.

Also changed bundler to stop trying to bundle wasm files — they must be included inline with JS code as data — and removed some now redundant code.

The crucial changes that enable support are:

1. The update to etcher-sdk@8 where some dependency fixes and updates took place
2. The downgrade and pinning of "electron-rebuild" to v3.2.3 until we’re able to update to Electron >= 14.2. The patch we need to avoid is https://github.com/electron/rebuild/pull/907. Also see: https://github.com/nodejs/node-gyp/issues/2673 and https://github.com/electron/rebuild/issues/913
3. A rule in webpack.config to ignore `aws-crt` which is a dependency of (ultimately) `aws4-axios` which is used by etcher-sdk and does a runtime check to its availability. We’re not currently using the “assume role” functionality (AFAIU) of aws4-axios and we don’t care that it’s not found, so force webpack to ignore the import. See https://github.com/aws/aws-sdk-js-v3/issues/3025

Change-type: minor