### PR TITLE
move EFP & success-banner to efp.balena.io

### DIFF
--- a/lib/gui/app/components/finish/finish.tsx
+++ b/lib/gui/app/components/finish/finish.tsx
@@ -43,7 +43,7 @@ function restart(goToMain: () => void) {
 async function getSuccessBannerURL() {
 	return (
 		(await settings.get('successBannerURL')) ??
-		'https://www.balena.io/etcher/success-banner?borderTop=false&darkBackground=true'
+		'https://efp.balena.io/success-banner?borderTop=false&darkBackground=true'
 	);
 }
 

--- a/lib/gui/app/pages/main/MainPage.tsx
+++ b/lib/gui/app/pages/main/MainPage.tsx
@@ -148,7 +148,7 @@ export class MainPage extends React.Component<
 	private async getFeaturedProjectURL() {
 		const url = new URL(
 			(await settings.get('featuredProjectEndpoint')) ||
-				'https://assets.balena.io/etcher-featured/index.html',
+				'https://efp.balena.io/index.html',
 		);
 		url.searchParams.append('borderRight', 'false');
 		url.searchParams.append('darkBackground', 'true');


### PR DESCRIPTION
Move EFP & Success-banner to https://efp.balena.io
This is the first pass on a better, lighter and faster EFP system.

Change-type: patch