### PR TITLE
patch: bump etcher-sdk to 8.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "electron-rebuild": "^3.2.9",
         "electron-updater": "5.3.0",
         "esbuild-loader": "2.20.0",
-        "etcher-sdk": "^8.3.0",
+        "etcher-sdk": "8.3.1",
         "file-loader": "6.2.0",
         "husky": "4.3.8",
         "i18next": "21.10.0",
@@ -10300,9 +10300,9 @@
       }
     },
     "node_modules/etcher-sdk": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.3.0.tgz",
-      "integrity": "sha512-ccxwTWtr/s2DWXX90wrBkWnKaCFYOpLknJk2crY6ZstvdSKuAp1EPGmPDiGucBFePV73yFbzoFTIPtk1LBbo4g==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.3.1.tgz",
+      "integrity": "sha512-OM1cb+BTdVpzTJaUphj61HkMCmuos21Jlk9EIk8aiH1B+af47/0iiRmQ50tSynC52Z+c8GUkNKK+ofr5bUl3qg==",
       "dev": true,
       "dependencies": {
         "@balena/node-beaglebone-usbboot": "^3.0.0",
@@ -28468,9 +28468,9 @@
       "dev": true
     },
     "etcher-sdk": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.3.0.tgz",
-      "integrity": "sha512-ccxwTWtr/s2DWXX90wrBkWnKaCFYOpLknJk2crY6ZstvdSKuAp1EPGmPDiGucBFePV73yFbzoFTIPtk1LBbo4g==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.3.1.tgz",
+      "integrity": "sha512-OM1cb+BTdVpzTJaUphj61HkMCmuos21Jlk9EIk8aiH1B+af47/0iiRmQ50tSynC52Z+c8GUkNKK+ofr5bUl3qg==",
       "dev": true,
       "requires": {
         "@balena/node-beaglebone-usbboot": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "electron-rebuild": "^3.2.9",
     "electron-updater": "5.3.0",
     "esbuild-loader": "2.20.0",
-    "etcher-sdk": "^8.3.0",
+    "etcher-sdk": "8.3.1",
     "file-loader": "6.2.0",
     "husky": "4.3.8",
     "i18next": "21.10.0",


### PR DESCRIPTION
To add "accept-encoding: gzip" header to HTTP request.
This prevents proxy on-the-fly decompression.