### PR TITLE
Add missing "sudo" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Package for Debian and Ubuntu can be downloaded from the [Github release page](h
    If you're missing dependencies you can fix them with:
 
    ```sh
-      sudo apt update && apt --fix-broken install #to add potential missing dependencies
+      sudo apt update && sudo apt --fix-broken install #to add potential missing dependencies
    ```
 
 ##### Uninstall


### PR DESCRIPTION
Here is what happens with the current instructions; 
```
20230504T072059Z: crystamped@margaret:~/Downloads₿ sudo apt update && apt --fix-broken install
Hit:1 http://us.archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://us.archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 https://brave-browser-apt-release.s3.brave.com stable InRelease           
Hit:4 https://cli.github.com/packages stable InRelease                          
Hit:5 http://us.archive.ubuntu.com/ubuntu jammy-backports InRelease             
Hit:6 http://security.ubuntu.com/ubuntu jammy-security InRelease                
Hit:7 https://ppa.launchpadcontent.net/mozillacorp/mozillavpn/ubuntu jammy InRelease 
Hit:8 https://packages.element.io/debian default InRelease                      
Get:9 https://pkgs.tailscale.com/stable/ubuntu focal InRelease       
Hit:10 https://ngrok-agent.s3.amazonaws.com buster InRelease 
Fetched 6,013 B in 1s (9,489 B/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
2 packages can be upgraded. Run 'apt list --upgradable' to see them. 
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied) 
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root? 
20230504T072108Z: crystamped@margaret:~/Downloads₿ 
```


Here is what happens when adding the missing "sudo": 
```
20230504T072113Z: crystamped@margaret:~/Downloads₿ sudo apt --fix-broken install 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Correcting dependencies... Done
The following additional packages will be installed:
  gconf2
Suggested packages:
  gconf-defaults-service
The following NEW packages will be installed:
  gconf2
0 upgraded, 1 newly installed, 0 to remove and 2 not upgraded. 1 not fully installed or removed.
Need to get 83.9 kB of archives.
After this operation, 631 kB of additional disk space will be used. Do you want to continue? [Y/n] 
Get:1 http://us.archive.ubuntu.com/ubuntu jammy/universe amd64 gconf2 amd64 3.2.6-7ubuntu2 [83.9 kB] 
Fetched 83.9 kB in 0s (453 kB/s)
Selecting previously unselected package gconf2.
(Reading database ... 302387 files and directories currently installed.) 
Preparing to unpack .../gconf2_3.2.6-7ubuntu2_amd64.deb ... 
Unpacking gconf2 (3.2.6-7ubuntu2) ...
Setting up gconf2 (3.2.6-7ubuntu2) ...
Setting up balena-etcher (1.18.4) ...
Processing triggers for man-db (2.10.2-1) ...
crystamped@margaret:~/Downloads₿
```