### PR TITLE
Prevent stealing window focus from auth dialog

### DIFF
--- a/lib/gui/etcher.ts
+++ b/lib/gui/etcher.ts
@@ -184,7 +184,7 @@ async function createMainWindow() {
 	mainWindow.setFullScreen(true);
 
 	// Prevent flash of white when starting the application
-	mainWindow.on('ready-to-show', () => {
+	mainWindow.once('ready-to-show', () => {
 		console.timeEnd('ready-to-show');
 		// Electron sometimes caches the zoomFactor
 		// making it obnoxious to switch back-and-forth


### PR DESCRIPTION
For some reason, after clicking the **Flash!** button, ```ready-so-show``` event is being fired. This causes [the code](https://github.com/balena-io/etcher/blob/a42be8ee747f3ecb41305d57f647a082c164e14e/lib/gui/etcher.ts#L192) to give focus to etcher window. On some systems this hides authentification dialog when user is entering their password, which is quite annoying.

Tested on: Kde plasma 5.27.5, Arch Linux
This pr should fix issues https://github.com/balena-io/etcher/issues/3620, https://github.com/balena-io/etcher/issues/3789

Demo:
Before: ![before](https://github.com/balena-io/etcher/assets/42062111/738cc06b-78e9-4a12-8e9f-4ec14c53d7a5)
After: ![after](https://github.com/balena-io/etcher/assets/42062111/d6a195bf-ac3a-422f-9d6d-6ec134255b6e)
