### PR TITLE
Replace deprecated flowzone input tests_run_on

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -18,7 +18,7 @@ jobs:
       (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
     with:
-      tests_run_on: '["ubuntu-20.04","windows-2019","macos-12","macos-latest-xlarge"]'
+      custom_runs_on: '[["ubuntu-20.04"],["windows-2019"],["macos-12"],["macos-latest-xlarge"]]'
       restrict_custom_actions: false
       github_prerelease: true
       cloudflare_website: "etcher"


### PR DESCRIPTION
The `custom_runs_on` array supports multiple runner labels in nested arrays.

Change-type: patch