### PR TITLE
Readme: Update Running on Wayland guide

### DIFF
--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -86,15 +86,15 @@ you want to learn more.
 Running on Wayland
 ------------------
 
-You can run Etcher on Wayland by passing command line flags
+You can run Etcher on Wayland by passing command line flags like so:
 
 ```sh
-$ balena-etcher --enable-features=WaylandWindowDecorations --ozone-platform=wayland
+balena-etcher --enable-features=WaylandWindowDecorations --ozone-platform=wayland
 ```
-To make this changes permanent to the desktop entry
+To make these changes permanent to the desktop entry, run these commands in your terminal:
 ```sh
-$ cp /usr/share/applications/balena-etcher.desktop ~/.local/share/applications
-$ sed -i 's|^Exec=/opt/balenaEtcher/balena-etcher %U$|Exec=/opt/balenaEtcher/balena-etcher --enable-features=WaylandWindowDecorations --ozone-platform=wayland %U|' ~/.local/share/applications/balena-etcher.desktop
+cp /usr/share/applications/balena-etcher.desktop ~/.local/share/applications
+sed -i 's|^Exec=/opt/balenaEtcher/balena-etcher %U$|Exec=/opt/balenaEtcher/balena-etcher --enable-features=WaylandWindowDecorations --ozone-platform=wayland %U|' ~/.local/share/applications/balena-etcher.desktop
 ```
 
 Runtime GNU/Linux dependencies

--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -86,17 +86,15 @@ you want to learn more.
 Running on Wayland
 ------------------
 
-Electron is based on Gtk2, which can't run natively on Wayland. Fortunately,
-the [XWayland Server][xwayland] provides backwards compatibility to run *any* X
-client on Wayland, including Etcher.
+You can run Etcher on Wayland by passing command line flags
 
-This usually works out of the box on mainstream GNU/Linux distributions that
-properly support Wayland. If it doesn't, make sure the `xwayland.so` module is
-being loaded by declaring it in your [weston.ini]:
-
+```sh
+$ balena-etcher --enable-features=WaylandWindowDecorations --ozone-platform=wayland
 ```
-[core]
-modules=xwayland.so
+To make this changes permanent to the desktop entry
+```sh
+$ cp /usr/share/applications/balena-etcher.desktop ~/.local/share/applications
+$ sed -i 's|^Exec=/opt/balenaEtcher/balena-etcher %U$|Exec=/opt/balenaEtcher/balena-etcher --enable-features=WaylandWindowDecorations --ozone-platform=wayland %U|' ~/.local/share/applications/balena-etcher.desktop
 ```
 
 Runtime GNU/Linux dependencies


### PR DESCRIPTION
Etcher can running on Wayland server without needing xwayland.
OS : Fedora 39
DE : Gnome 45.5 on Wayland
![gambar](https://github.com/balena-io/etcher/assets/86765295/e7601daa-46ed-4cf0-a342-db6e76660322)
