### PR TITLE
patch: prevent rebuild of native modules by @electron/rebuild

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -52,7 +52,9 @@ const config: ForgeConfig = {
 		},
 		...osxSigningConfig,
 	},
-	rebuildConfig: {},
+	rebuildConfig: {
+		onlyModules: [], // prevent rebuilding *any* native modules as they won't be used by electron but by the sidecar
+	},
 	makers: [
 		new MakerZIP(),
 		new MakerSquirrel({


### PR DESCRIPTION
Prevent the rebuilding of native modules by @electron/rebuild.
This was useless and waste times during the build as those modules are only used in the sidecar using another non-electron version of node (and packaged by pkg).
Now we only rebuild once for the correct target instead of twice.