### PR TITLE
patch: hold request for metadata while waiting for flasher

### DIFF
--- a/lib/gui/app/app.ts
+++ b/lib/gui/app/app.ts
@@ -142,25 +142,29 @@ export let requestMetadata: any;
 // start the api and spawn the child process
 spawnChildAndConnect({
 	withPrivileges: false,
-}).then(({ emit, registerHandler }) => {
-	// start scanning
-	emit('scan', {});
+})
+	.then(({ emit, registerHandler }) => {
+		// start scanning
+		emit('scan', {});
 
-	// make the sourceMetada awaitable to be used on source selection
-	requestMetadata = async (params: any): Promise<SourceMetadata> => {
-		emit('sourceMetadata', JSON.stringify(params));
+		// make the sourceMetada awaitable to be used on source selection
+		requestMetadata = async (params: any): Promise<SourceMetadata> => {
+			emit('sourceMetadata', JSON.stringify(params));
 
-		return new Promise((resolve) =>
-			registerHandler('sourceMetadata', (data: any) => {
-				resolve(JSON.parse(data));
-			}),
-		);
-	};
+			return new Promise((resolve) =>
+				registerHandler('sourceMetadata', (data: any) => {
+					resolve(JSON.parse(data));
+				}),
+			);
+		};
 
-	registerHandler('drives', (data: any) => {
-		setDrives(JSON.parse(data));
+		registerHandler('drives', (data: any) => {
+			setDrives(JSON.parse(data));
+		});
+	})
+	.catch((error: any) => {
+		throw new Error(`Failed to start the flasher process. error: ${error}`);
 	});
-});
 
 let popupExists = false;
 

--- a/lib/gui/app/components/source-selector/source-selector.tsx
+++ b/lib/gui/app/components/source-selector/source-selector.tsx
@@ -423,6 +423,14 @@ export class SourceSelector extends React.Component<
 						// this will send an event down the ipcMain asking for metadata
 						// we'll get the response through an event
 
+						// FIXME: This is a poor man wait while loading to prevent a potential race condition without completely blocking the interface
+						// This should be addressed when refactoring the GUI
+						let retriesLeft = 10;
+						while (requestMetadata === undefined && retriesLeft > 0) {
+							await new Promise((resolve) => setTimeout(resolve, 1050)); // api is trying to connect every 1000, this is offset to make sure we fall between retries
+							retriesLeft--;
+						}
+
 						metadata = await requestMetadata({ selected, SourceType, auth });
 
 						if (!metadata?.hasMBR && this.state.warning === null) {


### PR DESCRIPTION
This is a poor man wait while loading to prevent a potential race condition without completely blocking the interface
This should be properly addressed when we do a proper GUI refactoring.