### PR TITLE
patch: fix injection of analytics key at build time

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -136,25 +136,6 @@ const config: ForgeConfig = {
 		new sidecar.SidecarPlugin(),
 	],
 	hooks: {
-		readPackageJson: async (_config, packageJson) => {
-			packageJson.analytics = {};
-
-			if (process.env.SENTRY_TOKEN) {
-				packageJson.analytics.sentry = {
-					token: process.env.SENTRY_TOKEN,
-				};
-			}
-
-			if (process.env.AMPLITUDE_TOKEN) {
-				packageJson.analytics.amplitude = {
-					token: 'balena-etcher',
-				};
-			}
-
-			// packageJson.packageType = 'dmg' | 'AppImage' | 'rpm' | 'deb' | 'zip' | 'nsis' | 'portable'
-
-			return packageJson;
-		},
 		postPackage: async (_forgeConfig, options) => {
 			if (options.platform === 'linux') {
 				// symlink the etcher binary from balena-etcher to balenaEtcher to ensure compatibility with the wdio suite and the old name

--- a/lib/gui/etcher.ts
+++ b/lib/gui/etcher.ts
@@ -27,7 +27,7 @@ import { promises as fs } from 'fs';
 import { platform } from 'os';
 import * as path from 'path';
 import * as semver from 'semver';
-import * as lodash from 'lodash';
+import { once } from 'lodash';
 
 import './app/i18n';
 
@@ -37,7 +37,6 @@ import * as settings from './app/models/settings';
 import { buildWindowMenu } from './menu';
 import * as i18n from 'i18next';
 import * as SentryMain from '@sentry/electron/main';
-import * as packageJSON from '../../package.json';
 import { anonymizeSentryData } from './app/modules/analytics';
 
 import { delay } from '../shared/utils';
@@ -115,12 +114,15 @@ async function getCommandLineURL(argv: string[]): Promise<string | undefined> {
 	}
 }
 
-const initSentryMain = lodash.once(() => {
+const initSentryMain = once(() => {
 	const dsn =
-		settings.getSync('analyticsSentryToken') ||
-		lodash.get(packageJSON, ['analytics', 'sentry', 'token']);
+		settings.getSync('analyticsSentryToken') || process.env.SENTRY_TOKEN;
 
-	SentryMain.init({ dsn, beforeSend: anonymizeSentryData });
+	SentryMain.init({
+		dsn,
+		beforeSend: anonymizeSentryData,
+	});
+	console.log(SentryMain.getCurrentScope());
 });
 
 const sourceSelectorReady = new Promise((resolve) => {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -17,7 +17,7 @@
 import type { Configuration, ModuleOptions } from 'webpack';
 import { resolve } from 'path';
 
-import { BannerPlugin, IgnorePlugin } from 'webpack';
+import { BannerPlugin, IgnorePlugin, DefinePlugin } from 'webpack';
 
 const rules: Required<ModuleOptions>['rules'] = [
 	// Add support for native node modules
@@ -78,6 +78,15 @@ export const rendererConfig: Configuration = {
 		new BannerPlugin({
 			banner: '__REACT_DEVTOOLS_GLOBAL_HOOK__ = { isDisabled: true };',
 			raw: true,
+		}),
+		// Inject the analytics key into the code
+		new DefinePlugin({
+			'process.env.SENTRY_TOKEN': JSON.stringify(
+				process.env.SENTRY_TOKEN || '',
+			),
+			'process.env.AMPLITUDE_TOKEN': JSON.stringify(
+				process.env.AMPLITUDE_TOKEN || '',
+			),
 		}),
 	],
 


### PR DESCRIPTION
When we switched to electron-forge, we moved the injection of the analytics key to a `readPackageJson` hook.

This properly injects the keys in `package.json`. Unfortunately, the import of package.json is not dynamic and is done at build time by webpack *before* those keys are injected.

To circumvent the problem, this PR replaces the hook with a webpack `definePlugin` which will inject the key in the code at build time (it acts as a search and replace), the keys are not injected in the package.json anymore as that served no other purposes.