### PR TITLE
patch: fix missing windows dependency

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -55,6 +55,12 @@ runs:
         # fi
 
         npm ci
+
+        # as the shrinkwrap might have been done on mac/linux, this is ensure the package is there for windows
+        if [[runner.os == 'Windows']]; then
+          npm install winusb-driver-generator
+        fi
+
         npm run lint
         npm run package
         npm run wdio # test stage, note that it requires the package to be done first

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -88,7 +88,8 @@
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.8",
-        "utf-8-validate": "^5.0.10"
+        "utf-8-validate": "^5.0.10",
+        "winusb-driver-generator": "2.1.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8",
-    "utf-8-validate": "^5.0.10"
+    "utf-8-validate": "^5.0.10",
+    "winusb-driver-generator": "2.1.2"
   }
 }


### PR DESCRIPTION
The shrinkwrap has been done on mac which prevent windows specific module to be packaged
This should fix it.