### PR TITLE
patch: etcher-util is corrupted in RPM package

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -53,6 +53,13 @@ runs:
       shell: bash
       run: sudo apt-get install -y --no-install-recommends fakeroot dpkg rpm
 
+    # rpmbuild will strip binaries by default, which breaks the sidecar.
+    # Use a macro to override the "strip" to bypass stripping.
+    - name: Configure rpmbuild to not strip executables
+      if: runner.os == 'Linux'
+      shell: bash
+      run: echo '%__strip  /usr/bin/true' > ~/.rpmmacros
+
     - name: Install host dependencies
       if: runner.os == 'macOS'
       # FIXME: Python 3.12 dropped distutils that node-gyp depends upon.
@@ -131,7 +138,7 @@ runs:
           PLATFORM=Windows
           SHA256SUM_BIN=sha256sum
 
-          # Install DigiCert Signing Manager Tools      
+          # Install DigiCert Signing Manager Tools
           curl --silent --retry 3 --fail https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download \
             -H "x-api-key:$SM_API_KEY" \
             -o smtools-windows-x64.msi


### PR DESCRIPTION
Cherry-picking https://github.com/balena-io/etcher/pull/4304

---

rpmbuild strips executables by default when generating an rpm packge. This was causing the JavaScript code bundled in the etcher-util file to be removed, causing "Pkg: Error reading from file." whenever etcher-util was called.

This in turn caused balena-etcher to generate the error message `Error: (0, h.requestMetadata) is not a function` when attempting to write an SD card.

This fixes the issue for RPM builds by replacing the `strip` command with `true` so that rpmbuild no longer strips the executables and the embeded code stays intact.

See: https://github.com/balena-io/etcher/issues/4150