### PR TITLE
patch: bump etcher-sdk to 9.1.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -19,7 +19,7 @@
         "drivelist": "^12.0.2",
         "electron-squirrel-startup": "^1.0.0",
         "electron-updater": "6.1.8",
-        "etcher-sdk": "9.0.11",
+        "etcher-sdk": "9.1.2",
         "i18next": "23.11.2",
         "immutable": "3.8.2",
         "lodash": "4.17.21",
@@ -12955,9 +12955,10 @@
       }
     },
     "node_modules/etcher-sdk": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-9.0.11.tgz",
-      "integrity": "sha512-pWE+gqciw8V/NUnu/ywDLOUZZFdayx7ZJdZd5KVqIkm3pgEfAlpPgvmMNDnP9+b6/UW2wPaLy6NS8EiaDqK7tQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-9.1.2.tgz",
+      "integrity": "sha512-mFH8Q2CsqmPkWGjq7MX+WkN5ndGVBmtelYNjlB9E5nj3qXnNBBNbu3YR7P9s/Ft9HN73sKg5mP72xu/U0klG5Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@balena/node-beaglebone-usbboot": "^3.0.0",
         "@balena/udif": "^1.1.2",
@@ -12978,7 +12979,7 @@
         "lzma-native": "^8.0.6",
         "minimatch": "^9.0.3",
         "mountutils": "^1.3.20",
-        "node-raspberrypi-usbboot": "1.0.7",
+        "node-raspberrypi-usbboot": "1.1.0",
         "outdent": "^0.8.0",
         "partitioninfo": "^6.0.2",
         "rwmutex": "^1.0.0",
@@ -12990,7 +12991,7 @@
         "zip-part-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18 <22"
       },
       "optionalDependencies": {
         "winusb-driver-generator": "^2.0.0"
@@ -20407,12 +20408,13 @@
       }
     },
     "node_modules/node-raspberrypi-usbboot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.0.7.tgz",
-      "integrity": "sha512-ebL2xC7GQSrbrbAdaj2P6rWCViDoh0ewsgu3gHrtOCNeioCZ6ESirUob1iXT/0DCCMqUDPZA0VV3+euCPRruJw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.1.0.tgz",
+      "integrity": "sha512-X5+S+YO/jHcNosb+532shuSQAkaFrt9y0B+JiimTsH62gO+OenwBqWEEoVxrxr/fOtze30zPMe/66u/gA9WzhA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.3.4",
-        "usb": "^2.5.2"
+        "usb": "^2.12.1"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "drivelist": "^12.0.2",
     "electron-squirrel-startup": "^1.0.0",
     "electron-updater": "6.1.8",
-    "etcher-sdk": "9.0.11",
+    "etcher-sdk": "9.1.2",
     "i18next": "23.11.2",
     "immutable": "3.8.2",
     "lodash": "4.17.21",


### PR DESCRIPTION
notable:
- https://github.com/balena-io-modules/etcher-sdk/pull/327
- https://github.com/balena-io-modules/etcher-sdk/pull/326