### PR TITLE
major: build on ubuntu 22 and macos 13

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -21,18 +21,18 @@ jobs:
       custom_test_matrix: >
         {
           "os": [
-            ["ubuntu-20.04"],
+            ["ubuntu-22.04"],
             ["windows-2019"],
-            ["macos-12"],
+            ["macos-13"],
             ["macos-latest-xlarge"]
           ]
         }
       custom_publish_matrix: >
         {
           "os": [
-            ["ubuntu-20.04"],
+            ["ubuntu-22.04"],
             ["windows-2019"],
-            ["macos-12"],
+            ["macos-13"],
             ["macos-latest-xlarge"]
           ]
         }


### PR DESCRIPTION
This will drop support for ubuntu 20 (which will reach EoL in a few months) hence the major.
Macos upgrade shouldn't have any impact, but is necessary as there's no more macos12 public runner on GH.

https://balena.fibery.io/Work/Project/Bump-Etcher-minimum-supported-OS-to-Ubuntu-22.04-1148