### PR TITLE
Replace Debian gdk-pixbuf-xlib dep with libgdk-pixbuf-xlib-2.0-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
       "libfreetype6",
       "libgbm1",
       "libgcc1",
-      "libgdk-pixbuf2.0-0",
+      "libgdk-pixbuf-xlib-2.0-0",
       "libglib2.0-0",
       "libgtk-3-0",
       "liblzma5",


### PR DESCRIPTION
libgdk-pixbuf2.0-0 is a transitional package that has been removed in the upcoming Debian 13 (trixie).  This prevents balena-etcher from being installed on Debian testing and sid.

It is replaced by libgdk-pixbuf-xlib-2.0-0 has been available since Debian 11 (bullseye), released in August 2021.

See: https://packages.debian.org/unstable/libgdk-pixbuf2.0-0
See: https://packages.debian.org/unstable/libgdk-pixbuf-xlib-2.0-0

Fixes: https://github.com/balena-io/etcher/issues/4398

Change-Type: patch