### PR TITLE
Remove appimage format

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ the balena.io team will be happy to help.
 Etcher is free software and may be redistributed under the terms specified in
 the [license].
 
+## This is a dummy PR to test CI issue 
+
 [etcher]: https://balena.io/etcher
 [electron]: https://electronjs.org/
 [electron-supported-platforms]: https://electronjs.org/docs/tutorial/support#supported-platforms

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -86,12 +86,6 @@ const config: ForgeConfig = {
 				},
 			},
 		}),
-		new MakerAppImage({
-			options: {
-				icon: './assets/icon.png',
-				categories: ['Utility'],
-			},
-		}),
 		new MakerRpm({
 			options: {
 				icon: './assets/icon.png',


### PR DESCRIPTION
As reported many time in the issues, appimage is currently broken due to a security mechanism that prevent the sidekick to load and perform the flash.

As this is non-trivial to fix (if possible) I'm temporarily removing the app image target to avoid confusion.