### PR TITLE
replace deprecated dnf5 localinstall with dnf5 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Package for Fedora-based and Redhat can be downloaded from the [Github release p
 1. Install using yum
 
 ```sh
-   sudo yum localinstall balena-etcher-***.x86_64.rpm
+   sudo yum install balena-etcher-***.x86_64.rpm
 ```
 
 #### Arch/Manjaro Linux (GNU/Linux x64)


### PR DESCRIPTION
localinstall has been deprecated and removed in dnf5. attempting to use it on systems results in:
Unknown argument "localinstall" for command "dnf5". Add "--help" for more information about the arguments.
It could be a command provided by a plugin, try: dnf5 install 'dnf5-command(localinstall)'
i changed the line: sudo yum localinstall balena-etcher-***.x86_64.rpm
to: sudo yum install balena-etcher-***.x86_64.rpm