### PR TITLE
patch : Fix dependency bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       "libfreetype6",
       "libgbm1",
       "libgcc1",
-      "libgdk-pixbuf2.0-0",
+      "libgdk-pixbuf-2.0-0",
       "libglib2.0-0",
       "libgtk-3-0",
       "liblzma5",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       "libfreetype6",
       "libgbm1",
       "libgcc1",
-      "libgdk-pixbuf-2.0-0",
+      "libgdk-pixbuf2.0-0 | libgdk-pixbuf-2.0-0",
       "libglib2.0-0",
       "libgtk-3-0",
       "liblzma5",


### PR DESCRIPTION
The package 'libgdk-pixbuf2.0-0' changes this name for 'libgdk-pixbuf-2.0-0' in Debian 13. So I added 'libgdk-pixbuf-2.0-0' to choose the correct one in the dependencies list.