### PR TITLE
Add libgdk-pixbuf dependency alternatives to fix Ubuntu 26.04 installation

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -23,7 +23,7 @@ jobs:
           "os": [
             ["ubuntu-22.04"],
             ["windows-2022"],
-            ["macos-13"],
+            ["macos-14"],
             ["macos-latest-xlarge"]
           ]
         }
@@ -32,7 +32,7 @@ jobs:
           "os": [
             ["ubuntu-22.04"],
             ["windows-2022"],
-            ["macos-13"],
+            ["macos-14"],
             ["macos-latest-xlarge"]
           ]
         }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       "libfreetype6",
       "libgbm1",
       "libgcc1",
-      "libgdk-pixbuf2.0-0",
+      "libgdk-pixbuf2.0-0 | libgdk-pixbuf-2.0-0",
       "libglib2.0-0",
       "libgtk-3-0",
       "liblzma5",


### PR DESCRIPTION
Fixes: https://github.com/balena-io/etcher/issues/4602
Fixes: https://github.com/balena-io/etcher/issues/4623
Fixes: https://github.com/balena-io/etcher/issues/4550
Fixes: https://github.com/balena-io/etcher/issues/4543
Change-type: patch
See: https://balena.fibery.io/Work/Project/2581