### PR TITLE
Fix MacOS x86 build by switching to the macos-14-large GH runner

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -23,7 +23,7 @@ jobs:
           "os": [
             ["ubuntu-22.04"],
             ["windows-2022"],
-            ["macos-14"],
+            ["macos-14-large"],
             ["macos-latest-xlarge"]
           ]
         }
@@ -32,7 +32,7 @@ jobs:
           "os": [
             ["ubuntu-22.04"],
             ["windows-2022"],
-            ["macos-14"],
+            ["macos-14-large"],
             ["macos-latest-xlarge"]
           ]
         }


### PR DESCRIPTION
Fixes: https://github.com/balena-io/etcher/issues/4628
Change-type: patch
See: https://balena.fibery.io/Work/Project/2581
See: https://docs.github.com/en/actions/reference/runners/larger-runners
See: https://github.com/actions/runner-images