### PR TITLE
Add 'dnf install' instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Package for Fedora-based and Redhat can be downloaded from the [Github release p
 ```sh
    sudo yum localinstall balena-etcher-***.x86_64.rpm
 ```
+2. Install using dnf
+
+```sh
+   sudo dnf install ./balena-etcher-***.x86_64.rpm 
+```
 
 #### Arch/Manjaro Linux (GNU/Linux x64)
 


### PR DESCRIPTION
Downloading using yum was not working on Fedora 44. I followed the installation process the whole way but at the end I ran the sudo dnf install command that you see in the change and got it to successfully install

Etcher version: 2.1.6-1.x86_64