### PR TITLE
docs: update JSDoc link

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,4 +67,4 @@ be documented instead!
 [immutablejs]: http://facebook.github.io/immutable-js/
 [sass]: http://sass-lang.com
 [mocha]: http://mochajs.org
-[jsdoc]: http://usejsdoc.org
+[jsdoc]: https://jsdoc.app/


### PR DESCRIPTION
## Summary
- update the JSDoc reference in `docs/ARCHITECTURE.md` from the outdated `usejsdoc.org` URL to `https://jsdoc.app/`

Closes #4243

## Verification
- `git diff --check`
- `rg -n "usejsdoc|jsdoc\.app" docs/ARCHITECTURE.md`
- curl check: `https://jsdoc.app/` returns 200