### PR TITLE
feat: support zstd compressed images in the file picker

### DIFF
--- a/docs/MANUAL-TESTING.md
+++ b/docs/MANUAL-TESTING.md
@@ -39,6 +39,7 @@ Run the following tests with and without validation enabled:
 - [ ] Flash a XZ image
 - [ ] Flash a ZIP image
 - [ ] Flash a GZ image
+- [ ] Flash a Zstd image
 - [ ] Flash a DMG image
 - [ ] Flash an image whose size is not a multiple of 512 bytes
 - [ ] Flash a compressed image whose size is not a multiple of 512 bytes

--- a/lib/shared/supported-formats.ts
+++ b/lib/shared/supported-formats.ts
@@ -33,6 +33,8 @@ export const SUPPORTED_EXTENSIONS = [
 	'wic',
 	'xz',
 	'zip',
+	'zst',
+	'zstd',
 ];
 
 export function looksLikeWindowsImage(imagePath: string): boolean {


### PR DESCRIPTION
## What

Adds `zst` / `zstd` to `SUPPORTED_EXTENSIONS` so `.zstd` images appear in
the file-open dialog.

Decompression lives in etcher-sdk (`ZstdSource`,
balena-io-modules/etcher-sdk#373), which now depends on the standalone
[`@resadent/zstd-decompress-stream`](https://github.com/resadent/zstd-decompress-stream)
package. This change only advertises the extensions in the GUI. Detection is
content-based (magic bytes), so no renderer-side validation changes are needed.

> Depends on a released etcher-sdk with zstd support — please bump the
> `etcher-sdk` dependency to that release (e.g. 10.3.0) when merging. That
> release in turn depends on `@balena/zstd-decompress-stream` being published.

## Testing

- `npm run lint` clean ("No unexpected changes, all good").
- Manually flashed a zstd image with the SDK injected via
  `npx yalc add etcher-sdk`.
